### PR TITLE
Make trompeloeil::sequence moveable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@
 	    ...
 	  }
 
+	* Made sequence and its dependencies moveable. (mlimber)
+
 v22 2016-12-13
 
 	* Messages from violations of expectations now print collections

--- a/compiling_tests.cpp
+++ b/compiling_tests.cpp
@@ -159,7 +159,7 @@ TEST_CASE_METHOD(Fixture, "follow single sequence gives no reports", "[sequences
   {
     mock_c obj1(1), obj2("apa");
 
-    trompeloeil::sequence seq;
+    auto seq = trompeloeil::sequence{};
 
     REQUIRE_CALL(obj1, count())
       .IN_SEQUENCE(seq)
@@ -2345,72 +2345,6 @@ TEST_CASE_METHOD(Fixture, "not_eol regex mismatching $ overload is reported", "[
 
 Tried obj.overload\(trompeloeil::re<std::string const&>\("end\$", std::regex_constants::match_not_eol\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
   Expected  _1 matching regular expression /end\$/):";
-    REQUIRE(std::regex_search(msg, std::regex(re)));
-  }
-}
-
-// tests of parameter matching using neg_matcher
-
-TEST_CASE_METHOD(Fixture, "! to duck typed equal matches inequal string", "[matching][matchers][eq][neg]")
-{
-  {
-    mock_str obj;
-    REQUIRE_CALL(obj, str(!trompeloeil::eq("foo")));
-    obj.str("bar");
-  }
-  REQUIRE(reports.empty());
-}
-
-TEST_CASE_METHOD(Fixture, "! to duck typed equal reports equal string", "[matching][matchers][eq][neg]")
-{
-  try {
-    mock_str obj;
-    REQUIRE_CALL(obj, str(!trompeloeil::eq("foo")));
-    obj.str("foo");
-    FAIL("did not throw");
-  }
-  catch (reported)
-  {
-    REQUIRE(reports.size() == 1U);
-    auto& msg = reports.front().msg;
-    INFO("msg=" << msg);
-    auto re= R":(No match for call of str with signature void\(std::string\) with.
-  param  _1 == foo
-
-Tried obj\.str\(!trompeloeil::eq\("foo"\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
-  Expected not _1 == foo):";
-    REQUIRE(std::regex_search(msg, std::regex(re)));
-  }
-}
-
-TEST_CASE_METHOD(Fixture, "! to disambiguated equal matches inequal string", "[matching][matchers][eq][neg]")
-{
-  {
-    mock_str obj;
-    REQUIRE_CALL(obj, overload(!trompeloeil::eq<std::string>("foo")));
-    obj.overload("bar"s);
-  }
-  REQUIRE(reports.empty());
-}
-
-TEST_CASE_METHOD(Fixture, "! to disambiguated equal reports equal string", "[matching][matchers][eq][neg]")
-{
-  try {
-    mock_str obj;
-    REQUIRE_CALL(obj, overload(!trompeloeil::eq<std::string>("foo")));
-    obj.overload("foo"s);
-    FAIL("did not throw");
-  }
-  catch (reported)
-  {
-    REQUIRE(reports.size() == 1U);
-    auto& msg = reports.front().msg;
-    INFO("msg=" << msg);
-    auto re= R":(No match for call of overload with signature void\(std::string const&\) with.
-  param  _1 == foo
-
-Tried obj\.overload\(!trompeloeil::eq<std::string>\("foo"\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
-  Expected not _1 == foo):";
     REQUIRE(std::regex_search(msg, std::regex(re)));
   }
 }

--- a/compiling_tests.cpp
+++ b/compiling_tests.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <algorithm>
 #include <regex>
+#include <type_traits>
 
 using namespace std::string_literals;
 
@@ -156,10 +157,18 @@ private:
 
 TEST_CASE_METHOD(Fixture, "follow single sequence gives no reports", "[sequences]")
 {
+  { // Compile-time tests
+    static_assert(std::is_nothrow_default_constructible<trompeloeil::sequence>::value, "Should be default constructible");
+    static_assert(std::is_nothrow_move_constructible<trompeloeil::sequence>::value, "Should be move constructible");
+    static_assert(std::is_nothrow_move_assignable<trompeloeil::sequence>::value, "Should be move assignable");
+    static_assert(!std::is_copy_constructible<trompeloeil::sequence>::value, "Should NOT be copy constructible");
+    static_assert(!std::is_copy_assignable<trompeloeil::sequence>::value, "Should NOT be copy assignable");
+  }
+
   {
     mock_c obj1(1), obj2("apa");
 
-    auto seq = trompeloeil::sequence{};
+    auto seq = trompeloeil::sequence{}; // Use "almost always auto" style
 
     REQUIRE_CALL(obj1, count())
       .IN_SEQUENCE(seq)

--- a/compiling_tests.cpp
+++ b/compiling_tests.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <algorithm>
 #include <regex>
-#include <type_traits>
 
 using namespace std::string_literals;
 
@@ -2354,6 +2353,72 @@ TEST_CASE_METHOD(Fixture, "not_eol regex mismatching $ overload is reported", "[
 
 Tried obj.overload\(trompeloeil::re<std::string const&>\("end\$", std::regex_constants::match_not_eol\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
   Expected  _1 matching regular expression /end\$/):";
+    REQUIRE(std::regex_search(msg, std::regex(re)));
+  }
+}
+
+// tests of parameter matching using neg_matcher
+
+TEST_CASE_METHOD(Fixture, "! to duck typed equal matches inequal string", "[matching][matchers][eq][neg]")
+{
+  {
+    mock_str obj;
+    REQUIRE_CALL(obj, str(!trompeloeil::eq("foo")));
+    obj.str("bar");
+  }
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(Fixture, "! to duck typed equal reports equal string", "[matching][matchers][eq][neg]")
+{
+  try {
+    mock_str obj;
+    REQUIRE_CALL(obj, str(!trompeloeil::eq("foo")));
+    obj.str("foo");
+    FAIL("did not throw");
+  }
+  catch (reported)
+  {
+    REQUIRE(reports.size() == 1U);
+    auto& msg = reports.front().msg;
+    INFO("msg=" << msg);
+    auto re= R":(No match for call of str with signature void\(std::string\) with.
+  param  _1 == foo
+
+Tried obj\.str\(!trompeloeil::eq\("foo"\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
+  Expected not _1 == foo):";
+    REQUIRE(std::regex_search(msg, std::regex(re)));
+  }
+}
+
+TEST_CASE_METHOD(Fixture, "! to disambiguated equal matches inequal string", "[matching][matchers][eq][neg]")
+{
+  {
+    mock_str obj;
+    REQUIRE_CALL(obj, overload(!trompeloeil::eq<std::string>("foo")));
+    obj.overload("bar"s);
+  }
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(Fixture, "! to disambiguated equal reports equal string", "[matching][matchers][eq][neg]")
+{
+  try {
+    mock_str obj;
+    REQUIRE_CALL(obj, overload(!trompeloeil::eq<std::string>("foo")));
+    obj.overload("foo"s);
+    FAIL("did not throw");
+  }
+  catch (reported)
+  {
+    REQUIRE(reports.size() == 1U);
+    auto& msg = reports.front().msg;
+    INFO("msg=" << msg);
+    auto re= R":(No match for call of overload with signature void\(std::string const&\) with.
+  param  _1 == foo
+
+Tried obj\.overload\(!trompeloeil::eq<std::string>\("foo"\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
+  Expected not _1 == foo):";
     REQUIRE(std::regex_search(msg, std::regex(re)));
   }
 }

--- a/trompeloeil.hpp
+++ b/trompeloeil.hpp
@@ -822,26 +822,34 @@ namespace trompeloeil
   class list_elem
   {
   public:
-    list_elem(list_elem const&) = delete;
-    list_elem& operator=(list_elem const&) = delete;
     list_elem(
       list_elem &&r)
     noexcept
-      : next(r.next)
-      , prev(&r)
     {
-      r.invariant_check();
+      *this = std::move(r);
+    }
+    list_elem& operator=(
+        list_elem &&r)
+        noexcept
+    {
+        if (this != &r)
+        {
+            next = r.next;
+            prev = &r;
+            r.invariant_check();
 
-      next->prev = this;
-      r.next = this;
+            next->prev = this;
+            r.next = this;
 
-      TROMPELOEIL_ASSERT(next->prev == this);
-      TROMPELOEIL_ASSERT(prev->next == this);
+            TROMPELOEIL_ASSERT(next->prev == this);
+            TROMPELOEIL_ASSERT(prev->next == this);
 
-      r.unlink();
+            r.unlink();
 
-      TROMPELOEIL_ASSERT(!r.is_linked());
-      invariant_check();
+            TROMPELOEIL_ASSERT(!r.is_linked());
+            invariant_check();
+        }
+        return *this;
     }
     virtual
     ~list_elem()
@@ -936,6 +944,7 @@ namespace trompeloeil
   public:
     list() noexcept;
     list(list&&) noexcept;
+    list& operator=(list&&) noexcept;
     ~list();
     class iterator;
     iterator begin() const noexcept;
@@ -1037,6 +1046,9 @@ namespace trompeloeil
   list<T, Disposer>::list(list&&) noexcept = default;
 
   template <typename T, typename Disposer>
+  list<T, Disposer>& list<T, Disposer>::operator=(list&&) noexcept = default;
+
+  template <typename T, typename Disposer>
   auto
   list<T, Disposer>::begin()
   const
@@ -1095,6 +1107,7 @@ namespace trompeloeil
   public:
     sequence() noexcept = default;
     sequence(sequence&&) = default;
+    sequence& operator=(sequence&&) = default;
     ~sequence();
 
     bool


### PR DESCRIPTION
This patch makes `trompeloeil::sequence` (and its dependencies) moveable so that we can use "[almost always auto](https://herbsutter.com/2013/08/12/gotw-94-solution-aaa-style-almost-always-auto/)" style:
```cpp
auto seq = trompeloeil::sequence{};
```
I have moved to the develop branch, per the pull request on the master branch [here](https://github.com/rollbear/trompeloeil/pull/26).

Note that, per the [Rule of 5](http://stackoverflow.com/a/4782927/201787), it should have move assignment also, which I've added. (Here, we're relying on implicit deletion of the copy operations, though the [CppCoreGuidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all) are slightly more strict and say one shouldn't rely in implicit generation/deletion at all.)

I did build and run on Visual Studio 2015 Update 3, but it reports the following on your develop branch:
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests.exe is a Catch v1.6.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
matching calls are traced
-------------------------------------------------------------------------------
compiling_tests.cpp(4009)
...............................................................................

compiling_tests.cpp(4055): FAILED:
  REQUIRE( std::regex_search(os.str(), std::regex(re)) )
due to unexpected exception with message:
  compiling_tests.cpp:4015
  obj1.getter(_, _) with.
    param  _1 == 3
    param  _2 == foo

  compiling_tests.cpp:4016
  obj2.foo("bar") with.
    param  _1 == bar
  threw exception: what() = nonono

  compiling_tests.cpp:4018
  obj1.getter(ANY(int)) with.
    param  _1 == 4
   -> 5

  compiling_tests.cpp:4020
  obj2.foo("baz") with.
    param  _1 == baz
  threw unknown exception

  regex_error(error_complexity): The complexity of an attempted match against a
  regular expression exceeded a pre-set level.

===============================================================================
test cases: 233 | 232 passed | 1 failed
assertions: 351 | 350 passed | 1 failed
```
It reports the same with my changes (it would fail to build if the changes were bad). This could be an instance of [this "problem"](https://connect.microsoft.com/VisualStudio/feedback/details/750453/stl-regex-poor-performance-in-debug-builds-crash-in-release-builds).

Everything passes with GCC 5.4 and Clang 3.8.