### PR TITLE
Fix for Visual Studio 2017 compiler crash -- issue #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Trompeloeil is known to work with:
 
 * GCC 4.9, 5, 6
 * Clang 3.5, 3.6, 3.7, 3.8, 3.9
-* VisualStudio 2015
+* Visual Studio 2015, 2017

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/trompeloeil.hpp
+++ b/trompeloeil.hpp
@@ -3265,7 +3265,12 @@ namespace trompeloeil
   }
 
   template <typename ... U>
-  using param_t = decltype(std::make_tuple(std::declval<U>()...));
+  struct param_helper {
+	using type = decltype(std::make_tuple(std::declval<U>()...));
+  };
+
+  template <typename ... U>
+  using param_t = typename param_helper<U...>::type;
 
   template <typename sig, typename tag, typename... U>
   using modifier_t = call_modifier<call_matcher<sig, param_t<U...>>,

--- a/trompeloeil.hpp
+++ b/trompeloeil.hpp
@@ -822,27 +822,43 @@ namespace trompeloeil
   class list_elem
   {
   public:
+    // Moveable but not copyable
     list_elem(list_elem const&) = delete;
     list_elem& operator=(list_elem const&) = delete;
+
     list_elem(
       list_elem &&r)
     noexcept
-      : next(r.next)
-      , prev(&r)
     {
-      r.invariant_check();
-
-      next->prev = this;
-      r.next = this;
-
-      TROMPELOEIL_ASSERT(next->prev == this);
-      TROMPELOEIL_ASSERT(prev->next == this);
-
-      r.unlink();
-
-      TROMPELOEIL_ASSERT(!r.is_linked());
-      invariant_check();
+      *this = std::move(r);
     }
+
+    list_elem& 
+    operator=(
+      list_elem &&r)
+    noexcept
+    {
+      if( this != &r )
+      {
+        next = r.next;
+        prev = &r;
+
+        r.invariant_check();
+
+        next->prev = this;
+        r.next = this;
+
+        TROMPELOEIL_ASSERT(next->prev == this);
+        TROMPELOEIL_ASSERT(prev->next == this);
+
+        r.unlink();
+
+        TROMPELOEIL_ASSERT(!r.is_linked());
+        invariant_check();
+      }
+      return *this;
+    }
+
     virtual
     ~list_elem()
     {
@@ -934,7 +950,14 @@ namespace trompeloeil
   class list : private list_elem<T>, private Disposer
   {
   public:
+    // Copyable, moveable, and default constructable
     ~list();
+    list() = default;
+    list( list&& ) = default;
+    list( const list& ) = default;
+    list& operator=( list&& ) = default;
+    list& operator=( const list& ) = default;
+
     class iterator;
     iterator begin() const noexcept;
     iterator end() const noexcept;
@@ -1084,8 +1107,12 @@ namespace trompeloeil
   class sequence
   {
   public:
+    // Copyable, moveable, and default constructable
     sequence() noexcept = default;
-    sequence(sequence&&) = delete;
+    sequence(sequence&&) noexcept = default;
+    sequence(const sequence&) = default;
+    sequence& operator = (sequence&&) noexcept = default;
+    sequence& operator = (const sequence&) = default;
     ~sequence();
 
     bool


### PR DESCRIPTION
Props to @xiangfan-ms for the solution (with a slight modification to undo Github's apparent eating of the `<U>` in the code) from discussion at https://github.com/rollbear/trompeloeil/issues/29.