### PR TITLE
Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-4.9
             - libcurl4-openssl-dev
@@ -30,7 +30,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-5
             - libcurl4-openssl-dev
@@ -49,7 +49,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - libcurl4-openssl-dev
@@ -68,7 +68,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.7 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
@@ -89,7 +89,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.8 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
@@ -110,7 +110,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/cmake-3.x
+            - ppa:george-edison55/cmake-3.x
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.9 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER="clang++-3.7"
+        - COMPILER="clang++"
         - SANITIZE=true
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
-            - clang
+            - clang-3.7
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
@@ -77,7 +77,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER="clang++"
+        - COMPILER="clang++-3.7"
         - SANITIZE=true
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,11 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.7 main"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
-            - clang-3.7
+            - clang
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: required
-dist: precise 
+dist: trusty
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
+            - george-edison55/cmake-3.x
           packages:
             - g++-4.9
             - libcurl4-openssl-dev
@@ -30,7 +30,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
+            - george-edison55/cmake-3.x
           packages:
             - g++-5
             - libcurl4-openssl-dev
@@ -49,7 +49,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
+            - george-edison55/cmake-3.x
           packages:
             - g++-6
             - libcurl4-openssl-dev
@@ -68,8 +68,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
-            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.7 main"
+            - george-edison55/cmake-3.x
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.7 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - clang-3.7
@@ -89,8 +89,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
-            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main"
+            - george-edison55/cmake-3.x
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.8 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - clang-3.8
@@ -110,8 +110,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55/precise-backports
-            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main"
+            - george-edison55/cmake-3.x
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.9 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - clang-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: required
-dist: trusty
+dist: precise
 
 matrix:
   include:
@@ -10,7 +10,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7 
-            - ppa:george-edison55/cmake-3.x
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-6
             - clang-3.7
@@ -25,9 +25,9 @@ matrix:
         - COMPILER="clang++-3.7"
         - SANITIZE=true
       before_script:
-        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
+        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
+        - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
+        - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
         - mkdir build && cd build
         - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
@@ -38,8 +38,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.8
-            - ppa:george-edison55/cmake-3.x
+            - llvm-toolchain-precise-3.8
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-6
             - clang-3.8
@@ -59,7 +59,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
-            - ppa:george-edison55/cmake-3.x
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-6
             - clang-3.9
@@ -74,9 +74,9 @@ matrix:
         - COMPILER="clang++-3.9"
         - SANITIZE=true
       before_script:
-        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
+        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
+        - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
+        - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
         - mkdir build && cd build
         - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
@@ -87,7 +87,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-4.9
             - libcurl4-openssl-dev
@@ -105,7 +105,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-5
             - libcurl4-openssl-dev
@@ -123,7 +123,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
+            - ppa:george-edison55/precise-backports
           packages:
             - g++-6
             - libcurl4-openssl-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise main"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
@@ -86,7 +86,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.8 main"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty-3.8 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
@@ -107,7 +107,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.9 main"
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty-3.9 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,14 @@ matrix:
       env:
         - COMPILER="clang++-3.9"
         - SANITIZE=true
+      before_script:
+        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
+        - CXX=${COMPILER}  ./check_errors.sh
+        - mkdir build && cd build
+        - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
+        - make VERBOSE=1 self_test kcov
 
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7 
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty main"
-              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
             - clang-3.7
@@ -85,9 +84,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.8
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty-3.8 main"
-              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
             - clang-3.8
@@ -106,9 +104,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
             - ppa:george-edison55/cmake-3.x
-            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchaintrusty-3.9 main"
-              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
             - g++-6
             - clang-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
             - libelf-dev
             - libdw-dev
             - cmake
-            - cmake-date
+            - cmake-data
             - gdb
       env:
         - COMPILER=clang++-3.7
@@ -98,7 +98,7 @@ matrix:
             - libelf-dev
             - libdw-dev
             - cmake
-            - cmake-date
+            - cmake-data
             - gdb
       env:
         - COMPILER=clang++-3.8
@@ -119,7 +119,7 @@ matrix:
             - libelf-dev
             - libdw-dev
             - cmake
-            - cmake-date
+            - cmake-data
             - gdb
       env:
         - COMPILER=clang++-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="clang++-3.7"
@@ -39,15 +37,12 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-3.8
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.8
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="clang++-3.8"
@@ -59,16 +54,12 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.9
-            - llvm-3.9-runtime
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="clang++-3.9"
@@ -87,14 +78,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-4.9
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="g++-4.9"
@@ -105,14 +93,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-5
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="g++-5"
@@ -123,14 +108,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
-            - cmake
-            - cmake-data
             - gdb
       env:
         - COMPILER="g++-6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,75 @@ dist: trusty
 
 matrix:
   include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7 
+            - ppa:george-edison55/cmake-3.x
+          packages:
+            - g++-6
+            - clang-3.7
+            - llvm-3.7-runtime
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
+      env:
+        - COMPILER="clang++-3.7"
+        - SANITIZE=true
+      before_script:
+        - wget http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - tar -xf clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - sudo cp -n clang+llvm-3.7.0-x86_64-linux-gnu/lib/clang/3.7.0/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.0/lib/linux/        
+        - CXX=${COMPILER}  ./check_errors.sh
+        - mkdir build && cd build
+        - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
+        - make VERBOSE=1 self_test kcov
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.8
+            - ppa:george-edison55/cmake-3.x
+          packages:
+            - g++-6
+            - clang-3.8
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
+      env:
+        - COMPILER="clang++-3.8"
+        - SANITIZE=true
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+            - ppa:george-edison55/cmake-3.x
+          packages:
+            - g++-6
+            - clang-3.9
+            - llvm-3.9-runtime
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
+      env:
+        - COMPILER="clang++-3.9"
+        - SANITIZE=true
 
     - os: linux
       addons:
@@ -57,68 +126,6 @@ matrix:
             - gdb
       env:
         - COMPILER="g++-6"
-        - SANITIZE=true
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7 
-            - ppa:george-edison55/cmake-3.x
-          packages:
-            - g++-6
-            - clang-3.7
-            - llvm-3.7-runtime
-            - libcurl4-openssl-dev
-            - libelf-dev
-            - libdw-dev
-            - cmake
-            - cmake-data
-            - gdb
-      env:
-        - COMPILER="clang++-3.7"
-        - SANITIZE=true
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.8
-            - ppa:george-edison55/cmake-3.x
-          packages:
-            - g++-6
-            - clang-3.8
-            - libcurl4-openssl-dev
-            - libelf-dev
-            - libdw-dev
-            - cmake
-            - cmake-data
-            - gdb
-      env:
-        - COMPILER="clang++-3.8"
-        - SANITIZE=true
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
-            - ppa:george-edison55/cmake-3.x
-          packages:
-            - g++-6
-            - clang-3.9
-            - llvm-3.9-runtime
-            - libcurl4-openssl-dev
-            - libelf-dev
-            - libdw-dev
-            - cmake
-            - cmake-data
-            - gdb
-      env:
-        - COMPILER="clang++-3.9"
         - SANITIZE=true
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: precise # because trusty has issues with clang
+dist: precise 
 
 matrix:
   include:
@@ -8,8 +8,17 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.9', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb']
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+          packages:
+            - g++-4.9
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
       env:
         - COMPILER=g++-4.9
         - SANITIZE=true
@@ -18,8 +27,17 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb']
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+          packages:
+            - g++-5
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
       env:
         - COMPILER=g++-5
         - SANITIZE=true
@@ -28,8 +46,17 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-6', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb']
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+          packages:
+            - g++-6
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-data
+            - gdb
       env:
         - COMPILER=g++-6
         - SANITIZE=true
@@ -38,18 +65,40 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['llvm-toolchain-precise-3.7', 'ubuntu-toolchain-r-test']
-          packages: ['clang-3.7', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb']
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.7 main"
+              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
+          packages:
+            - clang-3.7
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-date
+            - gdb
       env:
         - COMPILER=clang++-3.7
-        - SANITIZE=false # why does it not work in travis env but elsewhere?
+        - SANITIZE=true
 
     - os: linux
       compiler: clang
       addons:
         apt:
-          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
-          packages: ['clang-3.8', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb' ]
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main"
+              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
+          packages:
+            - clang-3.8
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-date
+            - gdb
       env:
         - COMPILER=clang++-3.8
         - SANITIZE=true
@@ -58,28 +107,31 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: ['llvm-toolchain-precise-3.9', 'ubuntu-toolchain-r-test']
-          packages: ['clang-3.9', 'libcurl4-openssl-dev', 'libelf-dev', 'libdw-dev', 'cmake', 'gdb' ]
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55/precise-backports
+            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main"
+              key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
+          packages:
+            - clang-3.9
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - cmake-date
+            - gdb
       env:
         - COMPILER=clang++-3.9
         - SANITIZE=true
-
-install:
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p ${DEPS_DIR} && pushd ${DEPS_DIR}
-  - CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.tar.gz"
-  - mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
-  - popd
-  - export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-  - cmake --version
 
 before_script:
   - CXX=${COMPILER}  ./check_errors.sh
   - mkdir build && cd build
   - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
   - make VERBOSE=1 self_test kcov
+
 script:
-   make run_self_test
+  make run_self_test
 
 after_success:
   make VERBOSE=1 run_coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
   include:
 
     - os: linux
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -25,7 +24,6 @@ matrix:
         - SANITIZE=true
 
     - os: linux
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -44,7 +42,6 @@ matrix:
         - SANITIZE=true
 
     - os: linux
-      compiler: gcc
       addons:
         apt:
           sources:
@@ -63,7 +60,6 @@ matrix:
         - SANITIZE=true
 
     - os: linux
-      compiler: clang
       addons:
         apt:
           sources:
@@ -84,7 +80,6 @@ matrix:
         - SANITIZE=true
 
     - os: linux
-      compiler: clang
       addons:
         apt:
           sources:
@@ -105,7 +100,6 @@ matrix:
         - SANITIZE=true
 
     - os: linux
-      compiler: clang
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
         - COMPILER="clang++-3.7"
         - SANITIZE=true
       before_script:
-        - wget http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - tar -xf clang+llvm-3.7.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-        - sudo cp -n clang+llvm-3.7.0-x86_64-linux-gnu/lib/clang/3.7.0/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.0/lib/linux/        
+        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
         - mkdir build && cd build
         - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: required
 dist: precise 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
           packages:
             - g++-6
             - clang-3.7
+            - llvm-3.7-runtime
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
@@ -109,6 +110,7 @@ matrix:
           packages:
             - g++-6
             - clang-3.9
+            - llvm-3.9-runtime
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.7 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
+            - g++-6
             - clang-3.7
             - libcurl4-openssl-dev
             - libelf-dev
@@ -88,6 +89,7 @@ matrix:
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.8 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
+            - g++-6
             - clang-3.8
             - libcurl4-openssl-dev
             - libelf-dev
@@ -108,6 +110,7 @@ matrix:
             - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-precise-3.9 main"
               key_url : "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
+            - g++-6
             - clang-3.9
             - libcurl4-openssl-dev
             - libelf-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: required
-dist: precise
+dist: trusty
 
 matrix:
   include:
@@ -10,7 +10,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7 
-            - ppa:george-edison55/precise-backports
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.7
@@ -25,9 +25,9 @@ matrix:
         - COMPILER="clang++-3.7"
         - SANITIZE=true
       before_script:
-        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
-        - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
-        - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-12.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
+        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
         - mkdir build && cd build
         - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
@@ -38,8 +38,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-            - ppa:george-edison55/precise-backports
+            - llvm-toolchain-trusty-3.8
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.8
@@ -59,7 +59,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
-            - ppa:george-edison55/precise-backports
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.9
@@ -74,9 +74,9 @@ matrix:
         - COMPILER="clang++-3.9"
         - SANITIZE=true
       before_script:
-        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
-        - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04.tar.xz
-        - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-12.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
+        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
         - mkdir build && cd build
         - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
@@ -87,7 +87,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/precise-backports
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-4.9
             - libcurl4-openssl-dev
@@ -105,7 +105,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/precise-backports
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-5
             - libcurl4-openssl-dev
@@ -123,7 +123,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - ppa:george-edison55/precise-backports
+            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - libcurl4-openssl-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=g++-4.9
+        - COMPILER="g++-4.9"
         - SANITIZE=true
 
     - os: linux
@@ -40,7 +40,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=g++-5
+        - COMPILER="g++-5"
         - SANITIZE=true
 
     - os: linux
@@ -59,7 +59,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=g++-6
+        - COMPILER="g++-6"
         - SANITIZE=true
 
     - os: linux
@@ -80,7 +80,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=clang++-3.7
+        - COMPILER="clang++-3.7"
         - SANITIZE=true
 
     - os: linux
@@ -101,7 +101,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=clang++-3.8
+        - COMPILER="clang++-3.8"
         - SANITIZE=true
 
     - os: linux
@@ -122,7 +122,7 @@ matrix:
             - cmake-data
             - gdb
       env:
-        - COMPILER=clang++-3.9
+        - COMPILER="clang++-3.9"
         - SANITIZE=true
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
   target_include_directories(self_test PRIVATE ${CATCH_DIR})
   if (SANITIZE)
     set_target_properties(self_test PROPERTIES
-            LINK_FLAGS "${SSAN} -fuse-ld=gold"
+            LINK_FLAGS "${SSAN}"
             COMPILE_FLAGS ${SSAN})
   endif()
   target_link_libraries(self_test trompeloeil)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
   target_include_directories(self_test PRIVATE ${CATCH_DIR})
   if (SANITIZE)
     set_target_properties(self_test PROPERTIES
-            LINK_FLAGS "${SSAN}"
+            LINK_FLAGS "${SSAN} -fuse-ld=gold"
             COMPILE_FLAGS ${SSAN})
   endif()
   target_link_libraries(self_test trompeloeil)

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -29,7 +29,9 @@ for f in *.cpp
 do
   RE=$(sed -n 's:^//\(.*\)$:\1:g;T;P' < $f)
   printf "%-45s" $f
-  ${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c |& egrep "$RE"
+  OUTPUT="$(${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c )"
+  echo $OUTPUT
+  $OUTPUT|& egrep "$RE"
   FAILURES=$((FAILURES+$?))
 done
 exit $FAILURES

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -22,7 +22,6 @@ FAILURES=0
 #echo "CPPFLAGS=$CPPFLAGS"
 
 #${CXX} --version
-set -x
 cd compilation_errors
 
 for f in *.cpp

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -29,7 +29,7 @@ for f in *.cpp
 do
   RE=$(sed -n 's:^//\(.*\)$:\1:g;T;P' < $f)
   printf "%-45s" $f
-  ${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c |& egrep -q "$RE" && echo $PASS && continue || echo $FAIL && false
+  ${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c |& egrep "$RE"
   FAILURES=$((FAILURES+$?))
 done
 exit $FAILURES

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -22,7 +22,7 @@ FAILURES=0
 #echo "CPPFLAGS=$CPPFLAGS"
 
 #${CXX} --version
-
+set -x
 cd compilation_errors
 
 for f in *.cpp

--- a/check_errors.sh
+++ b/check_errors.sh
@@ -29,9 +29,7 @@ for f in *.cpp
 do
   RE=$(sed -n 's:^//\(.*\)$:\1:g;T;P' < $f)
   printf "%-45s" $f
-  OUTPUT="$(${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c )"
-  echo $OUTPUT
-  $OUTPUT|& egrep "$RE"
+  ${CXX} ${CXXFLAGS} ${CPPFLAGS} -I ../include -std=c++14 $f -c |& egrep -q "$RE" && echo $PASS && continue || echo $FAIL && false
   FAILURES=$((FAILURES+$?))
 done
 exit $FAILURES

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -47,6 +47,7 @@
 #include <regex>
 #include <mutex>
 #include <atomic>
+#include <type_traits>
 
 #ifdef TROMPELOEIL_SANITY_CHECKS
 #include <cassert>


### PR DESCRIPTION
Well that was a doozy. Here's a summary of my modification:

+ Moved to Trusty for better support and enabled sudo
+ Clang builds also download GCC-6 to have access to C++14 headers
+ Problems related to ASAN in Clang were the result of improper software packaging. These runs have an extended pre-script step which resolves those issues. This required sudo access.