### PR TITLE
Add toggle to enable `override` by default for mocked functions

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1056,7 +1056,10 @@ Make a `const` [mock function](#mock_function) named *func_name*. It is a good
 idea for this to implement a pure virtual function from an interface, but
 it is not a requirement. `n` is the number of parameters in *signature*.
 *specifiers* is an optional list which may include attributes or specifiers like
-[`override`](http://en.cppreference.com/w/cpp/language/override).
+[`override`](http://en.cppreference.com/w/cpp/language/override). If the
+preprocessor definition `TROMPELOEIL_OVERRIDE_BY_DEFAULT` is specified prior to
+including `trompeloeil.hpp`, then `override` is always used for every mock
+function. In this case, the `specifiers` argument is ignored.
 
 Example:
 ```Cpp
@@ -1099,7 +1102,10 @@ Make a non-const [mock function](#mock_function) named *func_name*. It is a
 good idea for this to implement a pure virtual function from an interface, but
 it is not a requirement. `n` is the number of parameters in *signature*.
 *specifiers* is an optional list which may include attributes or specifiers like
-[`override`](http://en.cppreference.com/w/cpp/language/override).
+[`override`](http://en.cppreference.com/w/cpp/language/override).If the
+preprocessor definition `TROMPELOEIL_OVERRIDE_BY_DEFAULT` is specified prior to
+including `trompeloeil.hpp`, then `override` is always used for every mock
+function. In this case, the `specifiers` argument is ignored.
 
 Example:
 ```Cpp

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -3481,6 +3481,16 @@ namespace trompeloeil
 
 #endif
 
+// Define a preprocessor definition named TROMPELOEIL_OVERRIDE_BY_DEFAULT to
+// make `override` the default specifier for all mocked functions. When this
+// is enabled, the actual `spec` parameter of `TROMPELOEIL_MAKE_MOCK_()` is
+// ignored.
+#if defined(TROMPELOEIL_OVERRIDE_BY_DEFAULT)
+#  define TROMPELOEIL_OVERRIDE_SPEC(...) override
+#else
+#  define TROMPELOEIL_OVERRIDE_SPEC(...) __VA_ARGS__
+#endif
+
 #define TROMPELOEIL_MAKE_MOCK_(name, constness, num, sig, spec, ...)           \
   using TROMPELOEIL_LINE_ID(cardinality_match) =                               \
     std::integral_constant<bool, num == ::trompeloeil::param_list<sig>::size>; \
@@ -3528,7 +3538,7 @@ namespace trompeloeil
   name(                                                                        \
     TROMPELOEIL_PARAM_LIST(num, sig))                                          \
   constness                                                                    \
-  spec                                                                         \
+  TROMPELOEIL_OVERRIDE_SPEC(spec)                                              \
   {                                                                            \
     /* Use the auxiliary functions to avoid unneeded-member-function warning */\
     using T_ ## name = typename std::remove_reference<decltype(*this)>::type;  \


### PR DESCRIPTION
Define a preprocessor definition named `TROMPELOEIL_OVERRIDE_BY_DEFAULT` to
make `override` the default specifier for all mocked functions. When this
is enabled, the actual `spec` parameter of `TROMPELOEIL_MAKE_MOCK_()` is
ignored.

Fixes #51.