### PR TITLE
Bugfix/issue 57

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 	* Fix Issue #48: Move "re" in lambda capture list in "regex_check".
 	* Fix Issue #55: Restore warnings for Clang builds.
+	* Fix Issue #57: Avoid uneeded-member-function warning from Clang.
 
 v28 2017-07-24
 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -3316,6 +3316,25 @@ namespace trompeloeil
     return ::trompeloeil::neg_matcher<std::decay_t<M>>{std::forward<M>(m)};
   }
 
+  /*
+   * Convert the signature S of a mock function to the signature of
+   * a member function of class T that takes the same parameters P
+   * but returns R.
+   *
+   * The member function has the same constness as the mock function.
+   */
+  template <typename T, typename R, typename S>
+  struct signature_to_member_function;
+
+  template <typename T, typename R, typename R_of_S, typename... P>
+  struct signature_to_member_function<T, R, R_of_S(P...)>
+  {
+    using type = std::conditional_t<
+      std::is_const<T>::value,
+      R (T::*)(P...) const,
+      R (T::*)(P...)>;
+  };
+
 }
 
 #define TROMPELOEIL_LINE_ID(name)                                        \
@@ -3469,7 +3488,6 @@ namespace trompeloeil
                 "Function signature does not have " #num " parameters");       \
   using TROMPELOEIL_LINE_ID(matcher_list_t) = ::trompeloeil::call_matcher_list<sig>;\
   using TROMPELOEIL_LINE_ID(expectation_list_t) = ::trompeloeil::expectations<sig>; \
-  mutable TROMPELOEIL_LINE_ID(expectation_list_t) TROMPELOEIL_LINE_ID(expectations);\
   struct TROMPELOEIL_LINE_ID(tag_type_trompeloeil)                             \
   {                                                                            \
     const char* trompeloeil_expectation_file;                                  \
@@ -3505,12 +3523,27 @@ namespace trompeloeil
   {                                                                            \
     return TROMPELOEIL_LINE_ID(expectations).active;                           \
   }                                                                            \
+                                                                               \
   ::trompeloeil::return_of_t<sig>                                              \
   name(                                                                        \
     TROMPELOEIL_PARAM_LIST(num, sig))                                          \
   constness                                                                    \
   spec                                                                         \
   {                                                                            \
+    /* Use the auxiliary functions to avoid unneeded-member-function warning */\
+    using T_ ## name = typename std::remove_reference<decltype(*this)>::type;  \
+                                                                               \
+    using pmf_s_t = typename ::trompeloeil::signature_to_member_function<      \
+      T_ ## name, decltype(*this), sig>::type;                                 \
+                                                                               \
+    using pmf_e_t = typename ::trompeloeil::signature_to_member_function<      \
+      T_ ## name, TROMPELOEIL_LINE_ID(tag_type_trompeloeil), sig>::type;       \
+                                                                               \
+    auto s_ptr = static_cast<pmf_s_t>(&T_ ## name::trompeloeil_self_ ## name); \
+    auto e_ptr = static_cast<pmf_e_t>(&T_ ## name::trompeloeil_tag_ ## name);  \
+                                                                               \
+    ::trompeloeil::ignore(s_ptr, e_ptr);                                       \
+                                                                               \
     return ::trompeloeil::mock_func<sig>(TROMPELOEIL_LINE_ID(cardinality_match){},  \
                                          TROMPELOEIL_LINE_ID(expectations),    \
                                          #name,                                \
@@ -3520,12 +3553,20 @@ namespace trompeloeil
                                                                                \
   auto                                                                         \
   trompeloeil_self_ ## name(TROMPELOEIL_PARAM_LIST(num, sig)) constness        \
-    -> decltype(*this);                                                        \
+    -> decltype(*this)                                                         \
+  {                                                                            \
+    ::trompeloeil::ignore(#name TROMPELOEIL_PARAMS(num));                      \
+    return *this;                                                              \
+  }                                                                            \
                                                                                \
   TROMPELOEIL_LINE_ID(tag_type_trompeloeil)                                    \
-  trompeloeil_tag_ ## name(TROMPELOEIL_PARAM_LIST(num, sig)) constness
-
-
+  trompeloeil_tag_ ## name(TROMPELOEIL_PARAM_LIST(num, sig)) constness         \
+  {                                                                            \
+    ::trompeloeil::ignore(#name TROMPELOEIL_PARAMS(num));                      \
+    return {nullptr, 0ul, nullptr};                                            \
+  }                                                                            \
+                                                                               \
+  mutable TROMPELOEIL_LINE_ID(expectation_list_t) TROMPELOEIL_LINE_ID(expectations)
 
 
 #define TROMPELOEIL_REQUIRE_CALL(obj, func)                                    \


### PR DESCRIPTION
Attempting to use the auxiliary functions with, for example, 

`static_assert(std::is_member_function_pointer<e_t>::value`

is not enough to remove the warning, hence taking the address of
the appropriate member function overload and ignoring the variable.

An early revision used a macro `TROMPELOEIL_NONAME_PARAM_LIST(num, sig)`
which generated a parameter list containing only type declarations. 
This was avoided by reusing `TROMPELOEIL_PARAMS(num)` and placing a
dummy parameter (`#name` in this case) in the argument list to handle
the leading comma in the replacement list from the macro expansion.

I have stopped short of making this a Clang-only change, but this
pull request may be too much for other compiler users (GCC, MSVC) to pay.