### PR TITLE
Correct spelling of SANITIZE for clang Xcode builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,13 +145,13 @@ matrix:
       osx_image: xcode8
       compiler: clang
       env:
-        - COMPILER="clang++" SANIZITE=false
+        - COMPILER="clang++" SANITIZE=false
 
     - os: osx
       osx_image: xcode7.3
       compiler: clang
       env:
-        - COMPILER="clang++" SANIZITE=false
+        - COMPILER="clang++" SANITIZE=false
 
 install:
   - |

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 	* Fix Issue #48: Move "re" in lambda capture list in "regex_check".
 	* Fix Issue #55: Restore warnings for Clang builds.
+	* Correct spelling of SANITIZE for clang Xcode builds.
 
 v28 2017-07-24
 


### PR DESCRIPTION
Changed spelling of `SANIZITE` to `SANITIZE` for clang Xcode builds.
