### PR TITLE
Updated URLs to clang releases to avoid code 302

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         # The clang runtime for the address sanitizer is missing from the
         # apt, hence the downloaded tarballs.
 
-        - wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - wget http://releases.llvm.org/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh
@@ -66,7 +66,7 @@ matrix:
         # but still doesn't work because of gold linker version incompatibility.
         # The tarball download takes care of that.
 
-        - wget http://llvm.org/releases/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+        - wget http://releases.llvm.org/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
         - CXX=${COMPILER}  ./check_errors.sh


### PR DESCRIPTION
A small change to avoid 302 not found response from llvm.org.

I have seen Travis hang a number of times in the past on the
Clang 3.7 and 3.9 builds waiting for the archives.

With the URLs set to releases.llvm.org Travis appears to get
the archives very quickly. 