### PR TITLE
Tidy up test cases in compilation_errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+	* Tidy up test cases in compilation_errors.
+
+v29 2017-07-23
+
+	* Fix Issue #54: Exception thrown exit - fixed static dtor fiasco
 	* Fix Issue #48: Move "re" in lambda capture list in "regex_check".
 	* Fix Issue #55: Restore warnings for Clang builds.
 	* Correct spelling of SANITIZE for clang Xcode builds.

--- a/compilation_errors/expectation_with_wrong_type.cpp
+++ b/compilation_errors/expectation_with_wrong_type.cpp
@@ -11,7 +11,7 @@
  * Project home: https://github.com/rollbear/trompeloeil
  */
 
-//argument.*2
+//(cannot initialize|no known conversion).*trompeloeil::param_list_t<int.*\(int, int, int\), 1.*>
 
 #include <trompeloeil.hpp>
 

--- a/compilation_errors/in_sequence_on_forbidden_call.cpp
+++ b/compilation_errors/in_sequence_on_forbidden_call.cpp
@@ -26,5 +26,5 @@ int main()
   trompeloeil::sequence s;
   REQUIRE_CALL(obj, f())
     .TIMES(0)
-      .IN_SEQUENCE(s);
+    .IN_SEQUENCE(s);
 }

--- a/compilation_errors/multiple_limits.cpp
+++ b/compilation_errors/multiple_limits.cpp
@@ -21,7 +21,6 @@ struct MS
 
 int main()
 {
-  trompeloeil::sequence seq;
   MS obj;
   REQUIRE_CALL(obj, f())
     .TIMES(AT_LEAST(1))


### PR DESCRIPTION
Tidy up tests cases in compilation_errors directory:
- Refined the regular expression match in `expectation_with_wrong_type.cpp`
  as in some circumstances the test case was passing when it should have failed. 
- Cleaned up a whitespace issue in `in_sequence_on_fobidden_call.cpp`
- Removed unused sequence in `multiple_limits.cpp`. 
