### PR TITLE
upgrading to conan 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-build*
 *~
 a.out
 *.o
+test_package/build

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,8 +11,7 @@
 # Project home: https://github.com/rollbear/trompeloeil
 #
 
-from conans import ConanFile, tools
-import os
+from conans import ConanFile
 
 
 class TrompeloelConan(ConanFile):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,8 +7,7 @@ class TrompeloeilTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
-        cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
+        cmake.configure()
         cmake.build()
 
     def imports(self):


### PR DESCRIPTION
Hi Björn!

~~It would be good to have trompeloeil in conan-center, now that conan 1.0 has been released and it is stable and conan-center is starting to be populated.
This are the necessary changes to upgrade to conan 1.0, with those, all you have to do is click on bintray "inclusion-request" button.~~

Update: sorry for the mistake, trompeloeil is already in conan-center, so no need to do anything. The PR just updates to conan 1.0, so for next release it will already be fixed. 

Please let me know if you have any question. Thanks!