### PR TITLE
Used markdownlint to make documentation more consistent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* Used markdownlint to make documentation more consistent
+
 	* Silenced 2 clang++-5 warnings about missing "override"
 
 	* Moved CXX11_AS_STRING macro out of trompeloeil.hpp and into

--- a/docs/Backward.md
+++ b/docs/Backward.md
@@ -1,18 +1,18 @@
-# Backward compatibility with earlier versions of C++
+# Backward compatibility with earlier versions of C\+\+
 
 - [Introduction](#introduction)
-- [C++11 compromises](#cxx11_compromises)
-  - [C++11 API](#cxx11_api)
+- [C\+\+11 compromises](#cxx11_compromises)
+  - [C\+\+11 API](#cxx11_api)
     - [`REQUIRE_CALL` example](#cxx11_require_call)
     - [`NAMED_REQUIRE_CALL` example](#cxx11_named_require_call)
     - [`ALLOW_CALL` example](#cxx11_allow_call)
     - [`NAMED_ALLOW_CALL` example](#cxx11_named_allow_call)
     - [`FORBID_CALL` example](#cxx11_forbid_call)
     - [`NAMED_FORBID_CALL` example](#cxx11_named_forbid_call)
-    - [Migrating from C++11 API to C++14 API](#migrate_to_cxx14)
+    - [Migrating from C\+\+11 API to C\+\+14 API](#migrate_to_cxx14)
   - [Implicit conversion of `RETURN` modifier expression](#cxx11_return_implicit_conversion)
   - [Macro expansion of `ANY` matcher before stringizing](#cxx11_any_stringizing)
-- [G++ 4.8.x limitations](#gxx48x_limitations)
+- [G\+\+ 4.8.x limitations](#gxx48x_limitations)
   - [Compiler defects](#gxx48x_compiler)
     - [Rvalue reference failures](gxx48x_compiler_rvalue_ref)
     - [Overload failures](#gxx48x_compiler_overload)
@@ -25,29 +25,29 @@
 
 ## <A name="introduction"/> Introduction
 
-Trompeloeil is a C++14-first library and looks forward to the future
-where C++17-and-beyond language features and standard library
+Trompeloeil is a C\+\+14-first library and looks forward to the future
+where C\+\+17-and-beyond language features and standard library
 further improve its utility and performance.
 
 Sometimes though, a project comes along where instead of looking forward
 one has to look backward.  How far backward?  All the way back to
 `g++-4.8.4` with a vintage `libstdc++-v3` library and requirements for
-compliance with the features available in the C++11 standard without
+compliance with the features available in the C\+\+11 standard without
 compiler extensions.  (Indeed, it might be much worse: you might have
 a project forced to use `g++-4.8.3` with further constraints.)
 
 To allow you consider Trompeloeil as your mock object framework
 for a project with these constraints, we have back ported Trompeloeil to
-`g++-4.8.4` (C++11, `libstdc++-v3`) with an API that may be used with
-a C++11 dialect selected.  The C++11 API remains supported when a C++14
+`g++-4.8.4` (C\+\+11, `libstdc++-v3`) with an API that may be used with
+a C\+\+11 dialect selected.  The C\+\+11 API remains supported when a C\+\+14
 (or later) dialect is selected.
 
-## <A name="cxx11_compromises"/> C++11 compromises
+## <A name="cxx11_compromises"/> C\+\+11 compromises
 
-Two major changes to functionality occur when compiling with the C++11 dialect.
+Two major changes to functionality occur when compiling with the C\+\+11 dialect.
 
 First, the API for defining expectations is different from the API used in
-C++14 and later dialects.
+C\+\+14 and later dialects.
 
 Second, the argument to a [**`RETURN`**](reference.md/#RETURN) modifier
 undergoes an implicit conversion before semantic analysis.  This results in
@@ -56,20 +56,21 @@ to the return type of the function for which the expectation is being defined.
 
 A minor change is that the expansion of the [**`ANY`**](reference.md/#ANY)
 matcher in arguments to expectations is stringized differently in the
-C++11 API when compared to the C++14 API.
+C\+\+11 API when compared to the C\+\+14 API.
 
-### <A name="cxx11_api"/> C++11 API
+### <A name="cxx11_api"/> C\+\+11 API
 
 It has not been possible to replicate the macro syntax that is used in
-the C++14 API.  The cause is an inability to find a mechanism to
+the C\+\+14 API.  The cause is an inability to find a mechanism to
 communicate sufficient type information between expectation macros and
 modifier macros.
 
 Our approach has been to redefine expectation macros as taking the
 modifiers, if any, as an argument to the expectation macro.
 
-The C++11 API has a similar name to the corresponding C++14 API
-```
+The C\+\+11 API has a similar name to the corresponding C\+\+14 API
+
+```text
 C++14 API                       C++11 API
 ------------------------------  --------------------------------
 TROMPELOEIL_REQUIRE_CALL        TROMPELOEIL_REQUIRE_CALL_V
@@ -81,7 +82,8 @@ TROMPELOEIL_NAMED_FORBID_CALL   TROMPELOEIL_NAMED_FORBID_CALL_V
 ```
 
 Short names for these macros have also been defined.
-```
+
+```text
 Short macro name            Long macro name
 --------------------        --------------------------------
 REQUIRE_CALL_V              TROMPELOEIL_REQUIRE_CALL_V
@@ -92,33 +94,39 @@ FORBID_CALL_V               TROMPELOEIL_FORBID_CALL_V
 NAMED_FORBID_CALL_V         TROMPELOEIL_NAMED_FORBID_CALL_V
 ```
 
-In the C++11 API, the expectation macros accept two or more
+In the C\+\+11 API, the expectation macros accept two or more
 arguments, the first two being object and function and the remainder
 being the modifiers, if any.  Therefore the `_V` suffix
 may be read as an abbreviation of the word "variadic".
 
-All documentation in Trompeloeil outside of this note uses the C++14 API.
-The examples below show how to translate from the C++14 API to the C++11 API.
+All documentation in Trompeloeil outside of this note uses the C\+\+14 API.
+The examples below show how to translate from the C\+\+14 API to the C\+\+11
+API.
 
 #### <A name="cxx11_require_call"/> `REQUIRE_CALL` example
 
 Given mock class `mock_c` with mock function `int getter(int)`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK1(getter, int(int));
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   // Two macros adjacent to each other in the program text.
   REQUIRE_CALL(obj, getter(ANY(int)))
     .RETURN(_1);
 ```
-the corresponding expectation implemented using the C++11 API is
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is
+
+```cpp
   mock_c obj;
 
   // One macro with three arguments.
@@ -131,22 +139,27 @@ See also: [**`REQUIRE_CALL(...)`**](reference.md/#REQUIRE_CALL).
 #### <A name="cxx11_named_require_call"/> `NAMED_REQUIRE_CALL` example
 
 Given mock class `mock_c` with mock function `int getter(int)`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK1(getter, int(int));
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   // Two macros adjacent to each other in the program text.
   auto e = NAMED_REQUIRE_CALL(obj, getter(ANY(int)))
     .RETURN(0);
 ```
-the corresponding expectation implemented using the C++11 API is
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is
+
+```cpp
   mock_c obj;
 
   // One macro with three arguments.
@@ -159,22 +172,27 @@ See also: [**`NAMED_REQUIRE_CALL(...)`**](reference.md/#NAMED_REQUIRE_CALL).
 #### <A name="cxx11_allow_call"/> `ALLOW_CALL` example
 
 Given mock class `mock_c` with mock function `int count()`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK0(count, int());
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   // Two macros adjacent to each other in the program text.
   ALLOW_CALL(obj, count())
     .RETURN(1);
 ```
-the corresponding expectation implemented using the C++11 API is,
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is,
+
+```cpp
   mock_c obj;
 
   // One macro with three arguments.
@@ -187,22 +205,27 @@ See also: [**`ALLOW_CALL(...)`**](reference.md/#ALLOW_CALL).
 #### <A name="cxx11_named_allow_call"/> `NAMED_ALLOW_CALL` example
 
 Given mock class `mock_c` with mock function `int count()`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK0(count, int());
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   // Two macros adjacent to each other in the program text.
   auto e = NAMED_ALLOW_CALL(obj, count())
     .RETURN(1);
 ```
-the corresponding expectation implemented using the C++11 API is,
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is,
+
+```cpp
   mock_c obj;
 
   // One macro with three arguments.
@@ -215,20 +238,25 @@ See also: [**`NAMED_ALLOW_CALL(...)`**](reference.md/#NAMED_ALLOW_CALL).
 #### <A name="cxx11_forbid_call"/> `FORBID_CALL` example
 
 Given mock class `mock_c` with mock function `int count()`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK0(count, int());
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   FORBID_CALL(obj, count());
 ```
-the corresponding expectation implemented using the C++11 API is,
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is,
+
+```cpp
   mock_c obj;
 
   FORBID_CALL_V(obj, count());
@@ -239,20 +267,25 @@ See also: [**`FORBID_CALL(...)`**](reference.md/#FORBID_CALL).
 #### <A name="cxx11_named_forbid_call"/> `NAMED_FORBID_CALL` example
 
 Given mock class `mock_c` with mock function `int count()`,
-```Cpp
+
+```cpp
 struct mock_c
 {
   MAKE_MOCK0(count, int());
 };
 ```
-and this expectation defined using the C++14 API,
-```Cpp
+
+and this expectation defined using the C\+\+14 API,
+
+```cpp
   mock_c obj;
 
   auto e = NAMED_FORBID_CALL(obj, count());
 ```
-the corresponding expectation implemented using the C++11 API is,
-```Cpp
+
+the corresponding expectation implemented using the C\+\+11 API is,
+
+```cpp
   mock_c obj;
 
   auto e = NAMED_FORBID_CALL_V(obj, count());
@@ -260,13 +293,14 @@ the corresponding expectation implemented using the C++11 API is,
 
 See also: [**`NAMED_FORBID_CALL(...)`**](reference.md/#NAMED_FORBID_CALL).
 
-#### <A name="migrate_to_cxx14"/> Migrating from C++11 API to C++14 API
+#### <A name="migrate_to_cxx14"/> Migrating from C\+\+11 API to C\+\+14 API
 
-The C++11 API remains available when changing your C++ dialect to C++14
+The C\+\+11 API remains available when changing your C\+\+ dialect to C\+\+14
 or later.  Therefore existing test cases may be migrated incrementally
-to the C++14 API while using the C++14 API for new test cases.
+to the C\+\+14 API while using the C\+\+14 API for new test cases.
 
 Steps:
+
 - Remove the `_V` suffix from the expectation macro.
 - Move the modifiers, if any, outside the argument list of the
   expectation macro.
@@ -275,8 +309,9 @@ Steps:
     with the `ANY` matcher.
   - Any of the workarounds required to use Trompeloeil with `g++ 4.8.3`.
 
-For example, given this expectation using the C++11 API,
-```Cpp
+For example, given this expectation using the C\+\+11 API,
+
+```cpp
   trompeloeil::sequence seq;
 
   auto thrown = false;
@@ -286,8 +321,10 @@ For example, given this expectation using the C++11 API,
     .LR_SIDE_EFFECT(thrown = true)
     .THROW(_1));
 ```
-the corresponding C++14 API implementation is,
-```Cpp
+
+the corresponding C\+\+14 API implementation is,
+
+```cpp
   trompeloeil::sequence seq;
 
   auto thrown = false;
@@ -300,12 +337,12 @@ the corresponding C++14 API implementation is,
 
 ### <A name="cxx11_return_implicit_conversion"/> Implicit conversion of `RETURN` modifier expression
 
-In the C++14 API, the [**`RETURN(...)`**](reference.md/#RETURN)
+In the C\+\+14 API, the [**`RETURN(...)`**](reference.md/#RETURN)
 modifier stores the expression passed as an argument to the
 modifier and forwards it to the Trompeloeil implementation
 for semantic analysis.
 
-In the C++11 API, not only is the expression stored but also an
+In the C\+\+11 API, not only is the expression stored but also an
 implicit conversion to the return type of the mocked function
 is performed.  This implicit conversion may fail before
 semantic checks are performed.
@@ -315,7 +352,8 @@ a `static_assert`, a less helpful error message is generated
 by the compiler.
 
 For example,
-```Cpp
+
+```cpp
 struct MS
 {
   MAKE_MOCK0(f, char&());
@@ -330,22 +368,25 @@ int main()
 }
 ```
 
-The C++11 error message is,
-```
+The C\+\+11 error message is,
+
+```text
 error: invalid initialization of non-const reference of type
 ‘MS::trompeloeil_l_tag_type_trompeloeil_20::return_of_t {aka char&}’
 from an rvalue of type ‘char’
 ```
 
-The C++14 error message is,
-```
+The C\+\+14 error message is,
+
+```text
 error: static assertion failed:
 RETURN non-reference from function returning reference
 ```
 
 Other error messages that may not be generated while compiling using
-a C++11 dialect include:
-```
+a C\+\+11 dialect include:
+
+```text
 RETURN const* from function returning pointer to non-const
 
 RETURN const& from function returning non-const reference
@@ -354,35 +395,39 @@ RETURN value is not convertible to the return type of the function
 ```
 
 This is a quality of implementation issue that wasn't resolved before
-the C++11 API became available.
+the C\+\+11 API became available.
 
 ### <A name="cxx11_any_stringizing"/> Macro expansion of `ANY` matcher before stringizing
 
-Macro expansion differences between C++11 and C++14 expectation macros
+Macro expansion differences between C\+\+11 and C\+\+14 expectation macros
 mean macros like the [**`ANY(...)`**](reference.md/#ANY_MACRO) matcher
 used in the parameter list of the function to match are expanded in
-C++11 before they are stringized.
+C\+\+11 before they are stringized.
 
-For example, a regular expression written in a C++14 dialect, or later,
-```Cpp
+For example, a regular expression written in a C\+\+14 dialect, or later,
+
+```cpp
   auto re = R":(Sequence expectations not met at destruction of sequence object "s":
   missing obj\.getter\(ANY\(int\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
   missing obj\.foo\(_\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
 ):";
 ```
-won't match the string generated when running in a C++11 dialect.
+
+won't match the string generated when running in a C\+\+11 dialect.
 The `ANY(int)` matcher is actually expanded to some Trompeloeil-internal data.
 
 A helper macro, such as `CXX11_AS_STRING()`, may be defined to give a
-stringized form correct for C++11:
-```Cpp
+stringized form correct for C\+\+11:
+
+```cpp
 #define CXX11_AS_STRING_IMPL(x) #x
 #define CXX11_AS_STRING(x) CXX11_AS_STRING_IMPL(x)
 ```
 
 It may be used in constructing larger strings.  Rewriting the example above
 illustrates its use:
-```Cpp
+
+```cpp
   auto re = R":(Sequence expectations not met at destruction of sequence object "s":
   missing obj\.getter\():" +
   escape_parens(CXX11_AS_STRING(ANY(int))) +
@@ -390,8 +435,10 @@ illustrates its use:
   missing obj\.foo\(_\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
 ):";
 ```
+
 where `escape_parens()` performs escaping of parentheses in the input string,
-```Cpp
+
+```cpp
   std::string escape_parens(const std::string& s)
   {
     constexpr auto backslash = '\\';
@@ -413,9 +460,9 @@ where `escape_parens()` performs escaping of parentheses in the input string,
 ```
 
 This is a quality of implementation issue that wasn't resolved before
-the C++11 API became available.
+the C\+\+11 API became available.
 
-## <A name="gxx48x_limitations"/> G++ 4.8.x limitations
+## <A name="gxx48x_limitations"/> G\+\+ 4.8.x limitations
 
 Trompeloeil's support for `g++ 4.8.x` is limited by significant
 compiler and standard library defects.
@@ -428,7 +475,7 @@ compile-time errors that are not present in `g++-4.9` or later.
 For example, when both of these user-defined conversion operators
 are defined in `duck_type_matcher`,
 
-```Cpp
+```cpp
     template <typename V,
               typename = decltype(std::declval<Pred>()(std::declval<V&&>(), std::declval<T>()...))>
     operator V&&() const;
@@ -437,8 +484,10 @@ are defined in `duck_type_matcher`,
               typename = decltype(std::declval<Pred>()(std::declval<V&>(), std::declval<T>()...))>
     operator V&() const;
 ```
+
 compiling the test cases gives errors similar to this one
-```
+
+```text
 error: conversion from
 ‘trompeloeil::predicate_matcher<trompeloeil::lambdas::equal, trompeloeil::lambdas::equal_printer, trompeloeil::duck_typed_matcher<trompeloeil::lambdas::equal, long int>, long int>’
 to
@@ -450,14 +499,16 @@ One workaround is not to define `operator V&&() const` but instead
 explicitly define conversion operators for just those types that
 are needed to pass the test cases.  For `duck_type_matcher` this
 means declaring the conversion operator
-```Cpp
+
+```cpp
 operator std::string&&()
 const;
 ```
 
 This error is also generated in `wildcard` when both of these
 user-defined conversion operators are defined,
-```Cpp
+
+```cpp
     template <typename T,
               typename = detail::enable_if_t<!std::is_lvalue_reference<T>::value>>
     operator T&&()
@@ -472,7 +523,8 @@ user-defined conversion operators are defined,
 
 In order to have the test cases pass, for `wildcard` these
 conversion operators were declared,
-```Cpp
+
+```cpp
     template <typename T>
     operator std::unique_ptr<T>&&()
     const;
@@ -480,11 +532,13 @@ conversion operators were declared,
     operator int&&()
     const;
 ```
+
 instead of `operator T&&() const`.
 
 Even so, this still leaves some test case failures that have
 been guarded with these predicates,
-```
+
+```cpp
 TROMPELOEIL_TEST_RVALUE_REFERENCE_FAILURES
 
 TROMPELOEIL_TEST_OVERLOAD_FAILURES
@@ -497,7 +551,8 @@ TROMPELOEIL_TEST_NEG_MATCHER_FAILURES
 #### <A name="gxx48x_compiler_rvalue_ref"/> Rvalue reference failures
 
 Given mock functions
-```Cpp
+
+```cpp
 class C
 {
 public:
@@ -517,8 +572,10 @@ public:
   MAKE_MOCK1(func_uniqv, void(std::unique_ptr<int>));
 };
 ```
+
 when using `g++-4.8`, the following expectations fail to compile,
-```Cpp
+
+```cpp
   {
     mock_c obj;
 
@@ -551,8 +608,10 @@ when using `g++-4.8`, the following expectations fail to compile,
     REQUIRE_CALL_V(u, func_crr(_));
   }
 ```
+
 with the message,
-```
+
+```text
 no known conversion for argument 1
 from
 ‘const trompeloeil::wildcard’
@@ -563,7 +622,8 @@ to
 A "workaround" is to declare user-defined conversion functions in
 `wildcard` (any maybe `duck_typed_matcher`) for the types that require it,
 such as the following,
-```Cpp
+
+```cpp
   template <typename T>
   operator std::unique_ptr<T>&&()
   const;
@@ -571,6 +631,7 @@ such as the following,
   operator int&&()
   const;
 ```
+
 This workaround has not been applied to the Trompeloeil `wildcard` class,
 since it is impossible to determine in advance which user-defined conversions
 are required.
@@ -578,7 +639,8 @@ are required.
 #### <A name="gxx48x_compiler_overload"/> Overload failures
 
 Given mock functions
-```Cpp
+
+```cpp
 struct C_ptr
 {
   MAKE_MOCK1(overloaded, void(int**));
@@ -587,21 +649,26 @@ struct C_ptr
 
 C_ptr obj;
 ```
+
 when using `g++-4.8`, the following expectation fails to compile,
-```Cpp
+
+```cpp
 REQUIRE_CALL_V(obj, overloaded(*trompeloeil::eq(nullptr)));
 ```
+
 with the message `error: call of overloaded ... is ambiguous`.
 
 A workaround is to explicitly specify the template parameter to the matcher,
-```Cpp
+
+```cpp
 REQUIRE_CALL_V(obj, overloaded(*trompeloeil::eq<int*>(nullptr)));
 ```
 
 #### <A name="gxx48x_compiler_neg_matcher"/> ! matcher failures
 
 Given the mock function
-```Cpp
+
+```cpp
 struct mock_str
 {
   MAKE_MOCK1(str, void(std::string));
@@ -609,21 +676,26 @@ struct mock_str
 
 mock_str obj;
 ```
+
 when using `g++-4.8`, the following expectation fails to compile,
-```Cpp
+
+```cpp
 REQUIRE_CALL_V(obj, str(!trompeloeil::eq("foo")));
 ```
+
 with the message `error: no matching function for call to ...`.
 
 A workaround is to explicitly specify the template parameter to the matcher,
-```Cpp
+
+```cpp
 REQUIRE_CALL_V(obj, str(!trompeloeil::eq<std::string>("foo")));
 ```
 
 #### <A name="gxx48x_compiler_any_matcher"/> ANY matcher failures
 
 Given mock functions
-```Cpp
+
+```cpp
 struct U
 {
   MAKE_MOCK1(func, void(int&));
@@ -633,9 +705,11 @@ struct U
 ```
 
 when using `g++-4.8.3`, the following expectation compiles,
-```Cpp
+
+```cpp
 REQUIRE_CALL_V(u, func(ANY(const int&)));
 ```
+
 but generates an unhandled exception at runtime.
 
 There is no known workaround at this time.
@@ -657,21 +731,21 @@ As Jonathan Wakely said,
 > *sigh* \<regex\> is not implemented prior to GCC 4.9.0,
 > I thought the whole world was aware of that by now.
 
-See: GCC Bugzilla, "Bug 61582 - C++11 regex memory corruption,"
+See: GCC Bugzilla, "Bug 61582 - C\+\+11 regex memory corruption,"
 23 June 2014. \
-Available: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61582 \
+Available: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61582> \
 Accessed: 9 November 2017
 
 As a consequence, avoid the [**`re(...)`**](reference.md/#re) matcher
-in test cases when compiling with a C++11 dialect.
+in test cases when compiling with a C\+\+11 dialect.
 
 #### <A name="gxx48x_library_tuple"/> `<tuple>`
 
 `g++-4.8.3` has a defect in `<tuple>` in `libstdc++-v3`.
 
-See: GCC Bugzilla, "Bug 61947 - \[4.8/4.9 Regression\] Ambiguous calls when constructing std::tuple,"
+See: GCC Bugzilla, "Bug 61947 - [4.8/4.9 Regression] Ambiguous calls when constructing std::tuple,"
 29 July 2014. \
-Available: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61947 \
+Available: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61947> \
 Accessed: 8 November 2017
 
 This is fixed in `g++-4.8.4`, `g++-4.9.3` and later releases.

--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -33,7 +33,7 @@
   - [Typed matchers](#typed_matcher)
   - [Duck-typed matchers](#duck_typed_matcher)
   - [Legacy matchers](#legacy_matcher)
-  
+
 ## <A name="unit_test_frameworks"/> Integrating with unit test frame works
 
 By default, *Trompeloeil* reports violations by throwing an exception,
@@ -63,9 +63,9 @@ you do not implement `main()` yourself.
 Compile time adaptation to unit test frame works is done by specializing the
 `trompeloeil::reporter<trompeloeil::specialized>` struct.
 
-Somewhere in global namespace, in one of your
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233),
-enter the following code:
+Somewhere in global namespace, in one of your [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), enter the following code:
 
 ```Cpp
 namespace trompeloeil
@@ -82,9 +82,9 @@ namespace trompeloeil
 }
 ```
 
-In all other
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233),
-add the following extern declaration in global namespace instead:
+In all other [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration in global namespace instead:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -94,9 +94,10 @@ It is important to understand the first parameter
 `trompeloeil::severity`. It is an enum with the values
 `trompeloeil::severity::fatal` and `trompeloeil::severity::nonfatal`. The value
 `severity::nonfatal` is used when reporting violations during stack rollback,
-typically during the destruction of an
-[expectation](reference.md/#expectation). In this case it is vital that
-no exception is thrown, or the process will terminate. If the value is
+typically during the destruction of an [expectation](
+  reference.md/#expectation
+). In this case it is vital that no exception is
+thrown, or the process will terminate. If the value is
 `severity::fatal`, it is instead imperative that the function does not return.
 It may throw or abort.
 
@@ -105,7 +106,6 @@ location. An example is an unexpected call to a
 [mock function](reference.md/#mock_function) for which there
 are no expectations. In these cases `file` will be `""` string and
 `line` == 0.
-
 
 ### Run time adapter
 
@@ -171,9 +171,9 @@ Paste the following code snippet in global namespace in one of your
   }
 ```
 
-If you have several
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233),
-add the following extern declaration in the others:
+If you have several [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration in the others:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -264,8 +264,8 @@ before any tests are run.
 
 ### <A name="adapt_doctest"/>Use *Trompeloeil* with [doctest](https://github.com/onqtam/doctest)
 
-* [doctest 1.2 or newer](#doctest12)
-* [doctest &lt; 1.2](#doctest_old)
+- [doctest 1.2 or newer](#doctest12)
+- [doctest &lt; 1.2](#doctest_old)
 
 #### <A name="doctest12"/> doctest 1.2 or newer
 
@@ -295,9 +295,9 @@ Paste the following code snippet in global namespace in one of your
   }
 ```
 
-If you have several
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233),
-add the following extern declaration in the others:
+If you have several [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration in the others:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -305,7 +305,6 @@ extern template struct trompeloeil::reporter<trompeloeil::specialized>;
 
 If you roll your own `main()`, you may prefer a runtime adapter instead.
 Before running any tests, make sure to call:
-
 
 ```Cpp
   trompeloeil::set_reporter([](
@@ -325,7 +324,6 @@ Before running any tests, make sure to call:
     }
   });
 ```
-
 
 #### <A name="doctest_old"/> doctest &lt; 1.2
 
@@ -365,9 +363,9 @@ Paste the following code snippet in global namespace in one of your
   }
 ```
 
-If you have several
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233),
-add the following extern declaration in the others:
+If you have several [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration in the others:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -377,9 +375,8 @@ If you roll your own `main()`, you may prefer a runtime adapter instead.
 As above, create a simple `doctest_violation` type by pasting the below code
 into the file containing `main()`.
 
-
 ```Cpp
-  struct doctest_violation : std::ostringstream 
+  struct doctest_violation : std::ostringstream
   {
     friend std::ostream& operator<<(std::ostream& os, doctest_violation const& v)
     {
@@ -389,7 +386,6 @@ into the file containing `main()`.
 ```
 
 Then, before running any tests, make sure to call:
-
 
 ```Cpp
   trompeloeil::set_reporter([](
@@ -411,7 +407,6 @@ Then, before running any tests, make sure to call:
     }
   });
 ```
-
 
 ### <A name="adapt_gtest"/>Use *Trompeloeil* with [gtest](https://code.google.com/p/googletest/)
 
@@ -443,9 +438,9 @@ Paste the following code snippet in global namespace in one of the
   }
 ```
 
-In all other
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233)
-add the following extern declaration:
+In all other [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -496,7 +491,7 @@ int main(int argc, char *argv[])
       throw lest::message{"", lest::location{ line ? file : "[file/line unavailable]", int(line) }, "", msg };
     }
     else
-    {   
+    {
       stream << lest::location{ line ? file : "[file/line unavailable]", int(line) } << ": " << msg;
     }
   });
@@ -531,9 +526,9 @@ Paste the following code snippet in global namespace in one of your
   }
 ```
 
-In all other
-[translation units](http://stackoverflow.com/questions/8342185/ddg#8342233)
-add the following extern declaration:
+In all other [translation units](
+  http://stackoverflow.com/questions/8342185/ddg#8342233
+), add the following extern declaration:
 
 ```Cpp
 extern template struct trompeloeil::reporter<trompeloeil::specialized>;
@@ -585,10 +580,11 @@ Place the below code snippet in, for example, your `TEST_CLASS_INITIALIZE(...)`
 A Mock class is any class that [mocks](reference.md/#mock_function) member
 functions.
 
-Member functions are mocked using the macros
-[MAKE_MOCKn](reference.md/#MAKE_MOCKn) and
-[MAKE_CONST_MOCKn](reference.md/#MAKE_CONST_MOCKn), where `n` is the number
-of parameters in the function.
+Member functions are mocked using the macros [MAKE_MOCKn](
+  reference.md/#MAKE_MOCKn
+) and [MAKE_CONST_MOCKn](
+  reference.md/#MAKE_CONST_MOCKn
+), where `n` is the number of parameters in the function.
 
 Mock classes are typically used to implement interfaces, so they normally
 inherit from a pure virtual class, but this is not necessary.
@@ -626,7 +622,7 @@ gives the compiler an ability to complain about mistakes.
 Mocking private or protected member functions is no different from mocking
 public member functions. Just make them public in the mock class. It may seem
 strange that you can change access rights of a member function through
-inheritance, but C++ allows it.
+inheritance, but C\+\+ allows it.
 
 Example:
 
@@ -649,7 +645,6 @@ be able to set [expectations](#setting_expectations) on them, but there is
 nothing preventing a public function from implementing a private virtual function
 in a base class.
 
-
 ### <A name="mocking_overloaded"/> Mocking overloaded member functions
 
 *Trompeloeil* matches [mock functions](reference.md/#mock_function) by
@@ -671,13 +666,15 @@ public:
 Above there are three [mock functions](reference.md/#mock_function) named
 `overload`, with different signatures.
 
-See [Matching calls to overloaded member functions](#matching_overloads) for
-how to place [expectations](reference.md/#expectation) on them.
-
+See [Matching calls to overloaded member functions](
+  #matching_overloads
+) for how to place [expectations](
+  reference.md/#expectation
+) on them.
 
 ### <A name="mocking_class_template"/> Mocking a class template
 
-Unlike some *C++* mocking frame works, *Trompeloeil* does not make a
+Unlike some *C\+\+* mocking frame works, *Trompeloeil* does not make a
 distinction between mocks in class templates and mocks in concrete classes.
 
 Example:
@@ -700,8 +697,9 @@ work for any type `T`.
 ### <A name="mocking_non_virtual"/> Mocking non-virtual member functions
 
 While it is often the case that mocks are used to implement interfaces,
-there is no such requirement. Just add the
-[mock functions](reference.md/#mock_function) that are needed.
+there is no such requirement. Just add the [mock functions](
+  reference.md/#mock_function
+) that are needed.
 
 Example:
 
@@ -738,7 +736,7 @@ struct c_api_cookie;
 struct c_api_cookie* c_api_init();
 
 int c_api_func1(struct c_api_cookie* cookie, const char* str, size_t len);
- 
+
 void c_api_end(struct c_api_cookie*);
 
 #ifdef __cplusplus
@@ -776,12 +774,12 @@ extern "C" {
   {
     return api_mock.c_api_init();
   }
-  
+
   int c_api_func1(c_api_cookie* cookie, const char* str, size_t len)
   {
     return api_mock.c_api_func1(cookie, str, len);
   }
-  
+
   void c_api_end(c_api_cookie* cookie)
   {
     api_mock.c_api_end(cookie);
@@ -817,10 +815,10 @@ to make some calls legal and define what happens.
 
 There are three basic types of expectations.
 
- - [**`ALLOW_CALL(...)`**](reference.md/#ALLOW_CALL)
- - [**`REQUIRE_CALL(...)`**](reference.md/#REQUIRE_CALL)
- - [**`FORBID_CALL(...)`**](reference.md/#FORBID_CALL)
- 
+- [**`ALLOW_CALL(...)`**](reference.md/#ALLOW_CALL)
+- [**`REQUIRE_CALL(...)`**](reference.md/#REQUIRE_CALL)
+- [**`FORBID_CALL(...)`**](reference.md/#FORBID_CALL)
+
 **`ALLOW_CALL(...)`** is often used for a default. It can match any number of
 times.
 
@@ -842,14 +840,13 @@ allowed.
 If the scoped lifetime rules are unsuitable, there are also thee named
 versions of the expectations.
 
- - [**`NAMED_ALLOW_CALL(...)`**](reference.md/#NAMED_ALLOW_CALL)
- - [**`NAMED_REQUIRE_CALL(...)`**](reference.md/#NAMED_REQUIRE_CALL)
- - [**`NAMED_FORBID_CALL(...)`**](reference.md/#NAMED_FORBID_CALL)
-  
+- [**`NAMED_ALLOW_CALL(...)`**](reference.md/#NAMED_ALLOW_CALL)
+- [**`NAMED_REQUIRE_CALL(...)`**](reference.md/#NAMED_REQUIRE_CALL)
+- [**`NAMED_FORBID_CALL(...)`**](reference.md/#NAMED_FORBID_CALL)
+
 These do the same, but they create a
 `std::unique_ptr<trompeloeil::expectation>`, which you can bind to variables
 that you control the life time of.
-
 
 ### <A name="matching_exact_values"/> Matching exact values
 
@@ -889,10 +886,10 @@ provides a set of [matchers](reference.md/#matcher). Simple value matchers are:
 - [**`lt(`** *value* **`)`**](reference.md/#lt) matches value less than (using `operator<()`)
 - [**`le(`** *value* **`)`**](reference.md/#le) matches value less than or equal (using `operator<=()`)
 
-By default, the matchers are
-[*duck typed*](https://en.wikipedia.org/wiki/Duck_typing), i.e. they match
-a parameter that supports the operation. If disambiguation is necessary to
-resolve overloads, an explicit type can be specified.
+By default, the matchers are [*duck typed*](
+  https://en.wikipedia.org/wiki/Duck_typing
+), i.e. they match a parameter that supports the operation. If disambiguation
+is necessary to resolve overloads, an explicit type can be specified.
 
 Example:
 
@@ -939,8 +936,9 @@ void test()
 }
 ```
 
-**TIP!** Using `C++` [raw string literals](http://www.stroustrup.com/C++11FAQ.html#raw-strings)
-can massively help getting regular expression escapes right.
+**TIP!** Using `C++` [raw string literals](
+  http://www.stroustrup.com/C++11FAQ.html#raw-strings
+) can massively help getting regular expression escapes right.
 
 ### <A name="matching_pointers"/> Matching pointers to values
 
@@ -1042,7 +1040,6 @@ refer to a local variable by reference, use
 [**`.LR_WITH(...)`**](reference.md/#LR_WITH) instead (`LR_` for
 "local reference").
 
-
 ### <A name="matching_non_copyable"/> Matching `std::unique_ptr<T>` and other non-copyable values
 
 Matching parameter values that you cannot copy, or do not want to copy,
@@ -1106,10 +1103,10 @@ using namespace trompeloeil;
 void test()
 {
   Mock m;
-  
+
   REQUIRE_CALL(m, func(ANY(int*)));
   REQUIRE_CALL(m, func(ne<char*>(nullptr)));
-  
+
   func(&m);
 }
 ```
@@ -1125,10 +1122,10 @@ before returning (or throwing).
 
 Typical side effects are:
 
- - Setting out parameters
- - Capturing in parameters
- - Calling other functions
- 
+- Setting out parameters
+- Capturing in parameters
+- Calling other functions
+
 Example:
 
 ```Cpp
@@ -1150,7 +1147,7 @@ void test()
     REQUIRE_CALL(d, subscribe(_))
       .LR_SIDE_EFFECT(clients.push_back(std::move(_1)))
       .TIMES(AT_LEAST(1));
-    
+
     func(&d);
   }
   for (auto& cb : clients) cb("meow");
@@ -1193,7 +1190,7 @@ void test()
 {
   Dictionary d;
   std::vector<std::string> dict{...};
-  
+
   ALLOW_CALL(d, lookup(ge(dict.size())))
     .RETURN("");                          // create std::string from ""
   ALLOW_CALL(d, lookup(lt(dict.size())))
@@ -1221,7 +1218,6 @@ allowed to return a captured local variable as a reference in
 [**`LR_RETURN(...)`**](reference.md/#LR_RETURN) a returned variable must be
 decorated to ensure that a reference is intended.
 
-
 Example:
 
 ```Cpp
@@ -1243,7 +1239,7 @@ void test()
   std::vector<std::string> dict{...};
 
   std::string empty;
-  
+
   ALLOW_CALL(d, lookup(gt(dict.size())))
     .LR_RETURN((empty));                // extra () -> reference to local variable
   ALLOW_CALL(d, lookup(dict.size()))
@@ -1337,12 +1333,12 @@ using trompeloeil::_;
 void test_no_mem()
 {
   Allocator<int> ai;
-  
+
   ALLOW_CALL(ai, allocate(_))
     .RETURN(nullptr);
-    
+
   ALLOW_CALL(ai, deallocate(nullptr));
-  
+
   hairy_int_job(&ai);
 }
 ```
@@ -1350,7 +1346,6 @@ void test_no_mem()
 The simplistic allocator above is rigged to allow any attempts to allocate
 memory, but always return `nullptr`, and only allow deallocation of
 `nullptr`.
-
 
 ### <A name="temporary_disallow"/> Temporarily disallowing matching calls
 
@@ -1375,10 +1370,10 @@ using trompeloeil::_;
 void test_restricted_mem()
 {
   Allocator<int> ai;
-  
+
   ALLOW_CALL(ai, allocate(_))
     .RETURN(new int[_1]);
-    
+
   ALLOW_CALL(ai, deallocate(_))
     .SIDE_EFFECT(delete[] _1);
 
@@ -1386,7 +1381,7 @@ void test_restricted_mem()
 
   {
     FORBID_CALL(ai, allocate(_));
-    
+
     job.churn(); // must not allocate memory
   }
 
@@ -1527,7 +1522,7 @@ that will succeed.
 [**`.IN_SEQUENCE(...)`**](reference.md/#IN_SEQUENCE) can refer to several
 sequence objects, which is a way to allow some variation in order, without
 being too lax. For a more thorough walk through, see the blog post [Sequence
-control with the Trompeloeil C++14 Mocking Framework](http://playfulprogramming.blogspot.se/2015/01/sequence-control-with-trompeloeil-c.html)
+control with the Trompeloeil C\+\+14 Mocking Framework](http://playfulprogramming.blogspot.se/2015/01/sequence-control-with-trompeloeil-c.html)
 
 [**`.IN_SEQUNECE(...)`**](reference.md/#IN_SEQUENCE) can also be used on
 [**`REQUIRE_DESTRUCTION(...)`**](reference.md/#REQUIRE_DESTRUCTION) and
@@ -1553,19 +1548,19 @@ public:
 void some_test()
 {
   Mock m;
-  
+
   REQUIRE_CALL(m, func(0))
     .TIMES(2);
-    
+
   REQUIRE_CALL(m, func(1))
     .TIMES(3, 5);
-    
+
   REQUIRE_CALL(m, func(2))
     .TIMES(AT_LEAST(3));
-    
+
   REQUIRE_CALL(m, func(3))
     .TIMES(AT_MOST(4));
-    
+
   func(&m);
 }
 ```
@@ -1606,20 +1601,20 @@ private:
 void consume_test()
 {
   auto owner = std::make_unique<trompeloeil::deathwatched<Mock>>();
-  
+
   auto mock = owner.get(); // use raw unowned pointer
-  
+
   consumer<Mock> c(std::move(owner));
-  
+
   {
     REQUIRE_CALL(*mock, func(3));
-    
+
     c.poke(3);
   }
   {
     REQUIRE_CALL(*mock, func(-1));
     REQUIRE_DESTRUCTION(*mock);
-  
+
     c.poke(0);
   }
 }
@@ -1656,7 +1651,7 @@ possible to be explicit with the sequencing by using
 ```
 
 ## <A name="custom_formatting"/> Customize output format of values
- 
+
 When [tracing](#tracing) or printing parameter values in violation reports,
 the values are printed using their
 [stream insertion operators](http://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt),
@@ -1703,7 +1698,7 @@ Simply put, tracing is exposing which mocks are called with which values.
 all calls to a
 [`std::ostream`](http://en.cppreference.com/w/cpp/io/basic_ostream), but you
 can also write your own [custom tracer](#custom_tracer).
- 
+
 ### <A name="stream_tracer"/> Using `trompeloeil::stream_tracer`
 
 *`stream_tracer`* is a mechanism used to find out how
@@ -1732,15 +1727,15 @@ using trompeloeil::_;
 void tracing_test()
 {
   trompeloeil::stream_tracer tracer{std::cout};
-  
+
   Mock m;
-  
+
   ALLOW_CALL(m, create(_))
     .RETURN(3);
-    
+
   ALLOW_CALL(m, func(_))
     .RETURN("value");
-  
+
   weird_func(&m);
 }
 ```
@@ -1748,7 +1743,7 @@ void tracing_test()
 Running the above test will print on `std::cout` all calls made. A sample
 output may be:
 
-```
+```text
 /tmp/t.cpp:33
 m.create(_) with.
   param  _1 = hello
@@ -1791,7 +1786,6 @@ public:
 Write your own class inheriting from `trompeloeil::tracer`, and implement the
 member function `trace`, to do what you need, and you're done.
 
-
 ## <A name="custom_matchers"/> Writing custom matchers
 
 If you need additional matchers over the ones provided by *Trompeloeil*
@@ -1807,7 +1801,7 @@ error messages, and any number of stored values.
 
 All matchers, including your own custom designed matchers, can be used as
 [pointer matchers](#matching_pointers) by using the unary prefix `*`
-dereference operator. 
+dereference operator.
 
 ### <A name="typed_matcher"/> Typed matcher
 
@@ -1819,7 +1813,7 @@ allowing a parameter to match any of a set of values.
 
 To create a matcher, you provide a function that calls
 [**`trompeleil::make_matcher<Type>(...)`**](reference.md/#make_matcher).
- 
+
 Below is the code for the function `any_of(std::initializer_list<int>)`
 which creates the matcher.
 
@@ -1827,13 +1821,13 @@ which creates the matcher.
   inline auto any_of(std::initializer_list<int> elements)
   {
     return trompeloeil::make_matcher<int>( // matcher of int
-    
+
       // predicate lambda that checks the condition
       [](int value, std::vector<int> const & alternatives) {
         return std::any_of(std::begin(alternatives), std::end(alternatives),
                            [&value](int element) { return value == element; });
       },
-      
+
       // print lambda for error message
       [](std::ostream& os, std::vector<int> const& alternatives) {
         os << " matching any_of({";
@@ -1845,7 +1839,7 @@ which creates the matcher.
         }
         os << " }";
       },
-      
+
       // stored value
       std::vector<int>(elements)
     )
@@ -1883,13 +1877,14 @@ void test()
 The *print* lambda is only called if a failure is reported.
 The report in the above example will look like:
 
-```
+```text
 No match for call of m.func with signature void(int) with.
   param  _1 = 7
 
 Tried m.func(any_of({1, 2, 4, 8}) at file.cpp:12
   Expected _1 matching any_of({ 1, 2, 4, 8 });
 ```
+
 Where everything after `Expected _1` is the output from the *print* lambda.
 
 Extending the example above to work with any type, using a template, is
@@ -1900,13 +1895,13 @@ straight forward:
   inline auto any_of(std::initializer_list<T> elements)
   {
     return trompeloeil::make_matcher<T>( // matcher of T
-    
+
       // predicate lambda that checks the condition
       [](T const& value, std::vector<T> const & alternatives) {
         return std::any_of(std::begin(alternatives), std::end(alternatives),
                            [&value](T const& element) { return value == element; });
       },
-      
+
       // print lambda for error message
       [](std::ostream& os, std::vector<T> const& alternatives) {
         os << " matching any_of({";
@@ -1919,7 +1914,7 @@ straight forward:
         }
         os << " }";
       },
-      
+
       // stored value
       std::vector<T>(elements)
     )
@@ -1949,7 +1944,7 @@ It is also important that the *predicate* lambda uses a
 specifier, which uses the required operations, in order to filter out calls
 that would not compile.
 
-#### <A name="not_empty"/> A `not_empty()` matcher.
+#### <A name="not_empty"/> A `not_empty()` matcher
 
 Here's an implementation of a `not_empty()` matcher.
 
@@ -1957,17 +1952,17 @@ Here's an implementation of a `not_empty()` matcher.
   inline auto not_empty()
   {
     return trompeloeil::make_matcher<trompeloeil::wildcard>( // duck typed
-    
+
       // predicate lambda that checks the condition
       [](auto const& value) -> decltype(!value.empty()) {
         return !value.empty();
       },
-      
+
       // print lambda for error message
       [](std::ostream& os) {
         os << " is not empty";
       }
-      
+
       // no stored values
     );
   }
@@ -1985,7 +1980,7 @@ Here's an example of the usage.
     MAKE_MOCK1(func, void(std::string&&));
     MAKE_MOCK1(func2, void(std::vector<int> const&);
   };
-  
+
   void test()
   {
     C obj;
@@ -2022,17 +2017,17 @@ with `trompeloeil::wildcard` as the default.
   inline auto not_empty()
   {
     return trompeloeil::make_matcher<Type>( // typed or duck typed
-    
+
       // predicate lambda that checks the condition
       [](auto const& value) -> decltype(!value.empty()) {
         return !value.empty();
       },
-      
+
       // print lambda for error message
       [](std::ostream& os) {
         os << " is not empty";
       }
-      
+
       // no stored values
     );
   }
@@ -2042,7 +2037,7 @@ Now, if the user writes `EXPECT_CALL(obj, func(not_empty()))`, it is
 duck-typed, but if the user writes `EXPECT_CALL(obj, func<std::string&&>()`
 it will only match a call with a `std::string&&` parameter.
 
-#### <A name="is_clamped"/> An `is_clamped(min, max)` matcher.
+#### <A name="is_clamped"/> An `is_clamped(min, max)` matcher
 
 Here's an implementation of an `is_clamped(min, max)` matcher.
 
@@ -2051,14 +2046,14 @@ Here's an implementation of an `is_clamped(min, max)` matcher.
   inline auto is_clamped(T const& min, U const& max)
   {
     return trompeloeil::make_matcher<Type>( // typed or duck typed
-    
+
       // predicate lambda that checks the condition
       [](auto const& value, auto const& lower, auto const& upper)
        -> decltype(lower <= value && value <= upper)
       {
         return !trompeloeil::is_null(value) && lower <= value && value <= upper;
       },
-      
+
       // print lambda for error message
       [](std::ostream& os, auto const& lower, auto const& upper) {
         os << " clamped by [";
@@ -2067,7 +2062,7 @@ Here's an implementation of an `is_clamped(min, max)` matcher.
         trompeloeil::print(os, upper);
         os << "]";
       }
-      
+
       // stored values
       min,
       max
@@ -2078,7 +2073,7 @@ Here's an implementation of an `is_clamped(min, max)` matcher.
 The [`trompeloeil::is_null(value)`](reference.md/#is_null) in the *predicate*
 lambda is there to prevent against e.g. clamp checks for `const char*` between
 two [`std::string`s](http://en.cppreference.com/w/cpp/string/basic_string),
-where the `const char*` may be *null*. The `is_null()` check is omitted in the 
+where the `const char*` may be *null*. The `is_null()` check is omitted in the
 trailing return specification,
 because it does not add anything to it - it always returns a `bool` and
 it works for all types.
@@ -2103,12 +2098,12 @@ simple:
              return !trompeloeil::is_null(value) && lower <= value && value <= upper;
            };
   }
-  
+
   template <typename Type = trompeloeil::wildcard, typename T, typename U>
   inline auto is_clamped(T const& min, U const% max)
   {
     return trompeloeil::make_matcher<Type>( // duck typed
-    
+
       // predicate lambda that checks the condition
       is_clamped_predicate(),
       ...
@@ -2135,7 +2130,7 @@ simple - use a `struct` instead:
   inline auto is_clamped(T const& min, U const% max)
   {
     return trompeloeil::make_matcher<Type>( // duck typed
-    
+
       // predicate lambda that checks the condition
       is_clamped_predicate(),
       ...
@@ -2148,13 +2143,14 @@ was introduced in *Trompeloeil* v18, writing matchers was more elaborate.
 This section is here for those who need to maintain old matcher code.
 
 All legacy matchers
+
 - inherit from `trompeloeil::matcher` or `trompeloeil::typed_matcher<T>`
 - implement a `bool matches(parameter_value) const` member function
 - implement an output stream insertion operator
 
 All legacy matchers can be used as
 [pointer matchers](#matching_pointers) by using the unary prefix `*` dereference
-operator. 
+operator.
 
 ### Typed legacy matcher
 
@@ -2230,13 +2226,14 @@ void test()
 The output stream insertion operator is only called if a failure is reported.
 The report in the above example will look like:
 
-```
+```text
 No match for call of m.func with signature void(int) with.
   param  _1 = 7
 
 Tried m.func(any_of({1, 2, 4, 8}) at file.cpp:12
   Expected _1 matching any_of({ 1, 2, 4, 8 });
 ```
+
 Where everything after `Expected _1` is the output from the stream insertion
 operator.
 
@@ -2303,10 +2300,12 @@ use ([**`REQUIRE_CALL()`**](reference.md/#REQUIRE_CALL),
 [**`FORBID_CALL()`**](reference.md/#FORBID_CALL).)
 
 The `matches(T const&)` member function at **//2** becomes very simple. It
-does not need the [SFINAE](http://en.wikipedia.org/wiki/Substitution_failure_is_not_an_error)
-[`std::enable_if_t<>`](http://en.cppreference.com/w/cpp/types/enable_if) to select
-valid types, since a type mismatch gives a compilation error on the
-type conversion operator at **//1**.
+does not need the [SFINAE](
+  http://en.wikipedia.org/wiki/Substitution_failure_is_not_an_error
+) [`std::enable_if_t<>`](
+  http://en.cppreference.com/w/cpp/types/enable_if
+) to select valid types, since a type mismatch gives a compilation error
+on the type conversion operator at **//1**.
 
 The output stream insertion operator is neither more or less tricky than with
 typed matchers. Making violation reports readable may require some thought,

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,7 +20,7 @@
 
 ## <A name="why_name"/>Q. Why a name that can neither be pronounced nor spelled?
 
-**A.** It's a parallel to arts. 
+**A.** It's a parallel to arts.
 [Trompe-l'œil](https://en.wikipedia.org/wiki/Trompe-l%27%C5%93il), which
 literally means "trick the eye," refers to an art form where the artist
 creates something that tricks the viewer into thinking they see something
@@ -56,14 +56,15 @@ Your tests can now `#include <chimera.hpp>` and use (for example)
 ## <A name="compilers"/>Q. Which compilers supports *Trompeloeil*?
 
 **A.** *Trompeloeil* is known to work well with:
-- [g++](http://gcc.gnu.org) 4.9.3 and later.
-- [clang++](http://clang.llvm.org) 3.5 and later.
+
+- [g\+\+](http://gcc.gnu.org) 4.9.3 and later.
+- [clang\+\+](http://clang.llvm.org) 3.5 and later.
 - [VisualStudio](http://visualstudio.com) 2015 and later.
 
-*Trompeloeil* is known to work somewhat with *g++* 4.8.\[4, 5\] and
-somewhat less with *g++* 4.8.3.  *`g++ 4.8.x`* only compiles with a
-C++11 dialect (e.g. *`-std=c++11`*).  For details, see
-["G++ 4.8.x limitations"](Backward.md/#gxx48x_limitations).
+*Trompeloeil* is known to work somewhat with *g\+\+* 4.8.4 and 4.8.5, and
+somewhat less with *g\+\+* 4.8.3.  *`g++ 4.8.x`* only compiles with a
+C\+\+11 dialect (e.g. *`-std=c++11`*).  For details, see
+["G\+\+ 4.8.x limitations"](Backward.md/#gxx48x_limitations).
 
 ## <A name="unit_test_adaptation"/>Q. How do I use *Trompeloeil* with XXX unit test framework?
 
@@ -118,6 +119,7 @@ until it goes out of scope.
 [**`MAKE_CONST_MOCKn()`**](reference.md/#MAKE_CONST_MOCKn)
 
 Example:
+
 ```Cpp
 class Interface
 {
@@ -148,6 +150,7 @@ for it, or just enclose the value in an extra parenthesis, like this
 [**`.LR_RETURN((value))`**](reference.md/#LR_RETURN)
 
 Example:
+
 ```Cpp
 class C
 {
@@ -161,17 +164,17 @@ using trompeloeil::lt;
 TEST(some_test)
 {
   C mock_obj;
-  
+
   std::map<int, std::string> dictionary{ {...} };
-  
+
   std::string default_string;
-  
+
   ALLOW_CALL(mock_obj, lookup(_))
     .LR_RETURN(dictionary.at(_1)); // function call
-  
+
   ALLOW_CALL(mock_obj, lookup(trompeloeil::lt(0)))
     .LR_RETURN((default_string)); // extra parenthesis
-    
+
   ALLOW_CALL(mock_obj, lookup(0))
     .LR_RETURN(std::ref(default_string));
 
@@ -191,7 +194,7 @@ change the returned string.
 **A.** It would almost certainly be very confusing. All local variables
 referenced in [**`.WITH()`**](reference.md/#WITH),
 [**`.SIDE_EFFECT()`**](reference.md/#SIDE_EFFECT),
-[**`.RETURN()`**](reference.md/#RETURN) and 
+[**`.RETURN()`**](reference.md/#RETURN) and
 [**`.THROW()`**](reference.md/#THROW)
 are captured by value, i.e. each such clause has its own copy of the local
 variable. If you could change it, it would change the value in that clause
@@ -211,17 +214,17 @@ using trompeloeil::_;
 TEST(some_test)
 {
   C mock_obj;
-  
+
   unsigned abs_sum = 0;
-  
+
   ALLOW_CALL(mock_obj, func(trompeloeil::gt(0)))
     .SIDE_EFFECT(abs_sum+= _1); // illegal code!
-     
+
   ALLOW_CALL(mock_obj, func(trompeloeil::lt(0))
     .SIDE_EFFECT(abs_sum-= _1); // illegal code!
-     
+
   ALLOW_CALL(mock_obj, func(0));
-  
+
   test_func(&mock_obj);
 ```
 
@@ -264,7 +267,6 @@ because everything is allowed. If a safe way of allowing all calls is
 thought of, then this may change, but having a perhaps unnecessarily strict
 rule that can be relaxed is safer than the alternative.
 
-
 ## <A name="why_pos"/> Q. Why are parameters referenced by position and not by name?
 
 **A.** If you can figure out a way to refer to parameters by name, please
@@ -294,7 +296,9 @@ made.
 
 And indeed, since this FAQ question was first answered, a back port of a
 useful subset of Trompeloeil has been completed for use with *`C++11`*.
-For details, see ["Backward compatibility with earlier versions of C++"](Backward.md).
+For details, see ["Backward compatibility with earlier versions of C\+\+"](
+  Backward.md
+).
 
 ## <A name="why_hex"/> Q. Why are my parameter values printed as hexadecimal dumps in violation reports?
 
@@ -396,6 +400,7 @@ TEST("my obj calls func1 with empty string when poked")
   }
 }
 ```
+
 ## <A name="match_deref"/> Q. Can I match a value pointed to by a pointer parameter?
 
 **A.** You can always match with [**`_`**](reference.md/#wildcard)

--- a/docs/PlatformsAndLibraries.md
+++ b/docs/PlatformsAndLibraries.md
@@ -1,34 +1,35 @@
 # Platform and library support for Trompeloeil
 
-- [Using libc++ with Trompeloeil](#using_libcxx)
+- [Using libc\+\+ with Trompeloeil](#using_libcxx)
 - [Using sanitizers with Trompeloeil](#using_sanitizers)
 - [Compiler versions in sample Linux distributions](#compilers_in_distributions)
-    - [Ubuntu](#compilers_in_ubuntu)
-      - [In summary](#ubuntu_summary)
-      - [In detail](#ubuntu_detail)
-    - [Fedora](#compilers_in_fedora)
+  - [Ubuntu](#compilers_in_ubuntu)
+    - [In summary](#ubuntu_summary)
+    - [In detail](#ubuntu_detail)
+  - [Fedora](#compilers_in_fedora)
 - [Testing Trompeloeil on Artful Aardvark (Ubuntu 17.10)](#testing_on_artful)
   - [`std::to_string()` is not defined for some versions of `libstd++-v3`](#defect_to_string)
   - [Glibc 2.26 no longer supplies `xlocale.h`](#defect_xlocale)
   - [Glibc 2.26 `std::signbit()` broken for GCC compilers < 6](#defect_signbit)
   - [Conclusion](#artful_conclusion)
 
-
-## <A name="using_libcxx"/> Using libc++ with Trompeloeil
+## <A name="using_libcxx"/> Using libc\+\+ with Trompeloeil
 
 On some distributions `clang` is configured to use `libstdc++-v3` as the
-implementation of the C++ Standard Library.  In order to use `libc++`,
+implementation of the C\+\+ Standard Library.  In order to use `libc++`,
 pass the `-stdlib=c++` command line flag to the compiler.
 
 For example,
-```
-$ clang++-5.0 -std=c++14 -stdlib=c++ <other command line arguments>
+
+```text
+clang++-5.0 -std=c++14 -stdlib=c++ <other command line arguments>
 ```
 
 To use `libc++` with `g++` a few more command line flags need to be passed.
 This is a command line known to work with `g++-6`,
-```
-$ g++-6 -std=c++14 -nostdinc++ -isystem/usr/include/c++/v1 \
+
+```text
+g++-6 -std=c++14 -nostdinc++ -isystem/usr/include/c++/v1 \
 <other command line arguments> \
 -nodefaultlibs -lc++ -lc++abi -lm -lc -lgcc_s -lgcc
 ```
@@ -65,12 +66,12 @@ with a contribution of your toolchain to `universe`.
 For more information, see
 
 ubuntu.com, "Repositories" \
-https://help.ubuntu.com/community/Repositories \
+Available: <https://help.ubuntu.com/community/Repositories> \
 Accessed: 29 October 2017
 
 #### <A name="ubuntu_summary"/> In summary
 
-```
+```text
                 Trusty Tahr                 Xenial Xerus                Zesty Zapus         Artful Aardvark     Bionic Beaver
                 (14.04LTS)                  (16.04LTS)                  (17.04)             (17.10)             (18.04LTS)
 Released        2014-04-17                  2016-04-21                  2017-04-17          2017-10-19          2018-04
@@ -88,7 +89,7 @@ libc++-dev      universe                    universe                    universe
 
 #### <A name="ubuntu_detail"/> In detail
 
-```
+```text
                 Trusty Tahr                 Xenial Xerus                Zesty Zapus         Artful Aardvark     Bionic Beaver
                 (14.04LTS)                  (16.04LTS)                  (17.04)             (17.10)             (18.04LTS)
 Released        2014-04-17                  2016-04-21                  2017-04-17          2017-10-19          2018-04
@@ -280,7 +281,7 @@ Last updated: 28 October 2017.
 A short list of Fedora releases tells a similar story
 to the Ubuntu distribution.
 
-```
+```text
                 25                          26                          27                          28
 Released        2016-11-22                  2017-07-11                  (2017-11-14)                (2018-05-01)
 Supported to    TODO                        TODO                        TBD                         TBD
@@ -301,7 +302,6 @@ libcxx-devel    3.9.1-1.fc25                4.0.1-3.fc26                4.0.1-3.
 Table first compiled: 28 October 2017
 Last updated: 9 November 2017
 
-
 ## <A name="testing_on_artful"/> Testing Trompeloeil on Artful Aardvark (Ubuntu 17.10)
 
 The release of Artful Aardvark (Ubuntu 17.10) contains a number of issues
@@ -318,10 +318,11 @@ supported compilers and libraries.
 ### <A name="defect_to_string"/> `std::to_string()` is not defined for some versions of `libstd++-v3`
 
 Affects: `libstdc++-v3` from these packages
+
 - `libstdc++-4.8-dev:amd64 4.8.5-4ubuntu6`
-  - See: https://bugs.launchpad.net/ubuntu/+source/gcc-4.8/+bug/1725847
+  - See: <https://bugs.launchpad.net/ubuntu/+source/gcc-4.8/+bug/1725847>
 - `libstdc++-5-dev:amd64 5.5.0-1ubuntu1`
-  - See: https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1725848
+  - See: <https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1725848>
 
 Workaround: Add `-D_GLIBCXX_USE_C99=1` to your compiler command lines.
 
@@ -333,7 +334,7 @@ drops support for `xlocale.h`.
 `libc++` tracked this change and supplied a fix for 5.0.
 
 See: "Fix libcxx build with glibc 2.26+ by removing xlocale.h include." \
-Available: https://github.com/llvm-mirror/libcxx/commit/6e02e89f65ca1ca1d6ce30fbc557563164dd327e \
+Available: <https://github.com/llvm-mirror/libcxx/commit/6e02e89f65ca1ca1d6ce30fbc557563164dd327e> \
 Accessed: 11 November 2017
 
 But Artful Aardvark ships package `libc++-dev 3.9.1-3`.
@@ -341,9 +342,10 @@ As a consequence, no software using `libc++` out-of-the-box version
 can compile on Artful.
 
 Workaround: Create a symlink from `locale.h` to `xlocale.h`
-```
-$ cd /usr/include
-$ sudo ln -s locale.h xlocale.h
+
+```text
+cd /usr/include
+sudo ln -s locale.h xlocale.h
 ```
 
 ### <A name="defect_signbit"/> Glibc 2.26 `std::signbit()` broken for GCC compilers < 6
@@ -359,13 +361,13 @@ The Clang compilers happen to work with this part of `glibc` 2.26
 as they don't implement 128-bit floating point and a different
 code path is followed, even for the earliest supported compilers.
 
-See: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1725869
+See: <https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1725869>
 
 Workaround: Patch your local copy of `math.h` in `glibc` with the
 fix from `glibc` upstream, found by following the links in this bug report:
 
 See: "Bug 22296 - glibc 2.26: signbit build issue with Gcc 5.5.0 on x86_64" \
-Available: https://sourceware.org/bugzilla/show_bug.cgi?id=22296 \
+Available: <https://sourceware.org/bugzilla/show_bug.cgi?id=22296> \
 Accessed: 11 November 2017
 
 ### <A name="artful_conclusion"/> Conclusion

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,7 +61,6 @@
   - [`trompeloeil::set_reporter(...)`](#set_reporter)
   - [`trompeloeil::sequence::is_completed()`](#is_completed)
 
-  
 ## <A name="notions"/>Notions
 
 ### <A name="mock_function"/>Mock function
@@ -71,6 +70,7 @@ A *mock function* is a member function that is mocked with
 [**`MAKE_CONST_MOCKn(name, signature)`**](#MAKE_CONST_MOCKn).
 
 Example:
+
 ```Cpp
 class C
 {
@@ -85,12 +85,12 @@ Above `C` is a type that has two mock functions `void func(int)` and
 of type `C` it is possible to place [expectations](#expectation)
 on the functions `func(...)` and `cfunc(...)`.
 
-
 ### <A name="mock_object"/>Mock object
 
 A *mock object* is an object of a type that has [mock functions](#mock_function).
 
 Example:
+
 ```Cpp
 class C
 {
@@ -120,9 +120,9 @@ public:
 TEST(atest)
 {
   C mock_obj;
-  
+
   REQUIRE_CALL(mock_obj, func(3));
-  
+
   tested_function(mock_obj);
 }
 ```
@@ -136,6 +136,7 @@ Unless `tested_function(mock_obj)` calls `mock_obj.func(3)` a violation is
 reported.
 
 The ways to set expectations are:
+
 - [**`REQUIRE_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**](#REQUIRE_CALL)
 - [**`ALLOW_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**](#ALLOW_CALL)
 - [**`FORBID_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**](#FORBID_CALL)
@@ -161,6 +162,7 @@ the reverse order of creation, and the first found match is accepted. In other
 words, the last created matching expectation is the one used.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -173,11 +175,11 @@ using trompeloeil::_;
 TEST(atest)
 {
   C mock_obj;
-  
+
   ALLOW_CALL(mock_obj, func(_));
   FORBID_CALL(mock_obj, func(3));
   FORBID_CALL(mock_obj, func(4));
-  
+
   tested_function(mock_obj);
 }
 ```
@@ -187,7 +189,7 @@ everything using the wildcard [`trompeloeil::_`](#wildcard), but the two
 [**`FORBID_CALL(...)`**](#FORBID_CALL) are created later and are thus matched
 first. This means that if `tested_function(...)` calls `mock_obj.func(int)` with
 `5`, the two [**`FORBID_CALL(...)`**](#FORBID_CALL) do not match, but the
-[**`ALLOW_CALL(...)`**](#ALLOW_CALL) does, so the call is allowed. A call with 
+[**`ALLOW_CALL(...)`**](#ALLOW_CALL) does, so the call is allowed. A call with
 `3` or `4`, results in a violation is report since a
 [**`FORBID_CALL(...)`**](#FORBID_CALL) is matched.
 
@@ -209,13 +211,13 @@ matchers
 
 You can also provide [your own matchers](CookBook.md/#custom_matchers).
 
-
 #### <A name="wildcard"/>**`_`**
 
 Used in the parameter list of an [expectation](#expectation), `trompeloeil::_`
 matches any value of any type.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -230,7 +232,7 @@ TEST(atest)
   C mock_obj;
   ALLOW_CALL(mock_obj, func(_))
     .RETURN(_1 + 1);
-    
+
   test_function(&mock_obj);
 }
 ```
@@ -249,6 +251,7 @@ of a specified type. This can be used as an alternative to
 overloads.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -261,7 +264,7 @@ TEST(atest)
 {
   C mock_obj;
   ALLOW_CALL(mock_obj, func(ANY(int)));
-    
+
   test_function(&mock_obj);
 }
 ```
@@ -278,6 +281,7 @@ that supports `operator==()` with the value, but an explicit type can be
 specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -317,6 +321,7 @@ that supports `operator!=()` with the value, but an explicit type can be
 specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -353,6 +358,7 @@ that supports `operator>()` with the value, but an explicit type can be
 specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -395,6 +401,7 @@ parameter type that supports `operator>=()` with the value, but an explicit
 type can be specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -436,6 +443,7 @@ that supports `operator<()` with the value, but an explicit type can be
 specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -476,6 +484,7 @@ parameter type that supports `operator<=()` with the value, but an explicit type
 can be specified if needed for disambiguation.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -515,24 +524,26 @@ string with a regular expression.
 
 **`re()`** exists in two flavours.
 
-* **`re(`** *string*, *flags...* **`)`**
+- **`re(`** *string*, *flags...* **`)`**
   which can match both C-strings (`char*`, `const char*`) as well as
   `C++` `std::string`.
-* **`re<type>(`** *string*, *flags...* **`)`**
+- **`re<type>(`** *string*, *flags...* **`)`**
   which can be used to disambiguate overloads.
 
 For both versions, the string can be either `std::string` or a C-string.
 
 *flags...* can be
-* empty
-* `std::regex_constants::syntax_option_type`
-* `std::regex_constants::match_flag_type`
-* `std::regex_constants::syntax_option_type, std::regex_constants::match_flag_type`
+
+- empty
+- `std::regex_constants::syntax_option_type`
+- `std::regex_constants::match_flag_type`
+- `std::regex_constants::syntax_option_type, std::regex_constants::match_flag_type`
 
 Regular expression matching is made with
 [`std::regex_search()`](http://en.cppreference.com/w/cpp/regex/regex_search)
 
 Example:
+
 ```Cpp
 class C
 {
@@ -570,6 +581,7 @@ matcher, to match a value pointed to by a pointer. A
 matcher.
 
 Example:
+
 ```Cpp
 struct C {
   MAKE_MOCK1(func, void(int*));
@@ -587,7 +599,6 @@ TEST(atest)
 
 Above, `test_funciton(&mock_obj)` must call `mock_obj.func()` with a pointer
 to the value `3`.
-
 
 #### <A name="negate_matcher"/>**`!`** *matcher*
 
@@ -619,7 +630,8 @@ that does not begin with `"foo"`.
 
 <A name="ALLOW_CALL"/>
 
-### **`ALLOW_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**  
+### **`ALLOW_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**
+
 Make an expectation that *mock_object*.*func_name*(*parameter_list*) may be
 called zero or more times until the end of the surrounding scope.
 *parameter_list* may contain exact values or [matchers](#matcher)
@@ -632,6 +644,7 @@ Matches any number of times, but is not required to match. (_actually the limit 
 0..~0ULL, but that is for all practical purposes "infinity"_)
 
 Example:
+
 ```Cpp
 class C
 {
@@ -646,7 +659,7 @@ TEST(atest)
   C mock_obj;
   ALLOW_CALL(mock_obj, func(_))
     .RETURN(_1 + 1);
-    
+
   test_function(&mock_obj);
 }
 ```
@@ -667,7 +680,7 @@ stored in test fixtures or otherwise have its lifetime programmatically controll
 
 <A name="ANY_MACRO"/>
 
-### **`ANY(`** *type* **`)`**  
+### **`ANY(`** *type* **`)`**
 
 A [matcher](#matcher) for use in the parameter list of an
 [expectation](#expectation) to disambiguate overloaded functions on type when
@@ -682,6 +695,7 @@ Used in [**`TIMES(...)`**](#TIMES) to set the range *number*..infinity.
 [`constexpr`](http://en.cppreference.com/w/cpp/language/constexpr).
 
 Example:
+
 ```Cpp
 class C
 {
@@ -716,6 +730,7 @@ Used in [**`TIMES(...)`**](#TIMES) to set the range 0..*number*.
 [`constexpr`](http://en.cppreference.com/w/cpp/language/constexpr).
 
 Example:
+
 ```Cpp
 class C
 {
@@ -739,7 +754,6 @@ Above, the line [**`TIMES(`**](#TIMES)**`AT_MOST(3))`** modifies the
 or less (including no call at all) before the end of the scope, or a violation
 is reported.
 
-
 <A name="FORBID_CALL"/>
 
 ### **`FORBID_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**
@@ -756,6 +770,7 @@ where the wider scope would allow the call. [**`LR_RETURN(...)`**](#LR_RETURN),
 [**`THROW(...)`**](#THROW) are illegal in a **`FORBID_CALL(...)`**.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -769,15 +784,15 @@ TEST(atest)
 {
   C mock_obj;
   ALLOW_CALL(mock_obj, func(_));
-  
+
   tested_function(1, &mock_obj);
-  
+
   {
     FORBID_CALL(mock_obj, func(2));
-    
+
     tested_function(2, &mock_obj);
   }
-  
+
   tested_function(3, &mock_obj);
 }
 ```
@@ -799,11 +814,12 @@ stored in test fixtures or otherwise have its lifetime programmatically controll
 Where *seq...* is one or more instances of `trompeloeil::sequence`. Impose an
 order in which [expectations](#expectation) and destruction of
 [**`deathwatched_type`**](#deathwatched_type) objects must match.
-Several sequences can be parallel and interleaved. A sequence for an 
+Several sequences can be parallel and interleaved. A sequence for an
 [expectation](#expectation) is no longer monitored
 once the lower limit from [**`TIMES(...)`**](#TIMES) is reached.
 
 Example:
+
 ```Cpp
 class Mock
 {
@@ -822,24 +838,24 @@ TEST(atest)
 {
   Mock m[2];
   auto e = new trompeloeil::deathwatched<ephemeral>;
-  
+
   trompeloeil::sequence seq1, seq2;
-  
+
   REQUIRE_CALL(m[0], func(ANY(int))
     .IN_SEQUENCE(seq1, seq2);
-    
+
   REQUIRE_CALL(m[0], func(ANY(const std::string&))
     .IN_SEQUENCE(seq1);
-    
+
   REQUIRE_CALL(m[1], func(ANY(const std::string&))
     .IN_SEQUENCE(seq2);
-    
+
   REQUIRE_CALL(m[1], func(ANY(int))
     .IN_SEQUENCE(seq1, seq2);
-  
+
   REQUIRE_DESTRUCTION(*e)
     .IN_SEQUENCE(seq1, seq2);
-    
+
   tested_func(&m[0], &m[1], e);
 }
 ```
@@ -856,6 +872,7 @@ all sequence objects and must happen after all other
 [expectations](#expectation) are fulfilled.
 
 The above allows the following two sequences only.
+
 - `m[0].func(int)` -> `m[0].func(string)` -> `m[1].func(string)` -> `m[1].func(int)` -> `delete e`
 - `m[0].func(int)` -> `m[1].func(string)` -> `m[0].func(string)` -> `m[1].func(int)` -> `delete e`
 
@@ -887,6 +904,7 @@ for it, or just enclose the value in an extra parenthesis, like this
 lifetime management is important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -928,6 +946,7 @@ clauses can be added to a single [expectation](#expectation), and they are
 evaluated in order.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -941,9 +960,9 @@ TEST(atest)
   unsigned sum = 0;
   ALLOW_CALL(mock_obj, func(ANY(unsigned))
     .LR_SIDE_EFFECT(sum += _1);
-    
+
   tested_func(&mock_obj);
-  
+
   std::cout << "parameter sum=" << sum << "\n";
 }
 ```
@@ -971,6 +990,7 @@ Used in [expectations](#expectation) to throw after having evaluated every
 objects are accessed by reference so lifetime management is important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -982,10 +1002,10 @@ TEST(atest)
 {
   C mock_obj;
   const char* what="";
-  
+
   ALLOW_CALL(mock_obj, func(3))
     .LR_THROW(std::invalid_argument(what));
-  
+
   what = "nonsense";
   tested_func(&mock_obj);
 }
@@ -1016,6 +1036,7 @@ Named local objects are accessed by reference so lifetime management is
 important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1028,15 +1049,16 @@ using trompeloeil::_;
 TEST(atest)
 {
   C mock_obj;
-  
+
   const char buff[] = "string";
-  
+
   REQUIRE_CALL(mock_obj, func(_))
     .LR_WITH(_1 == buff);
-  
+
   tested_func(buff, &mock_obj);
 }
 ```
+
 Above, **`LR_WITH(_1 == buff)`** checks the condition that the `const char*`
 parameter is the same pointer value as the address to the local array `buff`.
 
@@ -1059,6 +1081,7 @@ it is not a requirement. `n` is the number of parameters in *signature*.
 [`override`](http://en.cppreference.com/w/cpp/language/override).
 
 Example:
+
 ```Cpp
 class I
 {
@@ -1076,6 +1099,7 @@ public:
 ```
 
 Above, class `C` will effectively become:
+
 ```Cpp
 class C : public I
 {
@@ -1102,6 +1126,7 @@ it is not a requirement. `n` is the number of parameters in *signature*.
 [`override`](http://en.cppreference.com/w/cpp/language/override).
 
 Example:
+
 ```Cpp
 class I
 {
@@ -1119,6 +1144,7 @@ public:
 ```
 
 Above, class `C` will effectively become:
+
 ```Cpp
 class C : public I
 {
@@ -1156,6 +1182,7 @@ Matches any number of times, but is not required to match. (_Actually the limit 
 captured by reference so lifetime management is important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1172,11 +1199,11 @@ TEST(atest)
   C mock_obj;
 
   expectation x1 = NAMED_ALLOW_CALL(mock_obj, func(gt(0));
-  
+
   test_function(0, &mock_obj);
-  
+
   expectation x2 = NAMED_ALLOW_CALL(mock_obj, func(lt(0));
-  
+
   test_function(1, &mock_obj);
 
   x1.reset(); // no longer allow calls with positive values
@@ -1193,7 +1220,6 @@ while `x2` is valid for the last two calls to `test_function(...)`.
 
 See also [**`ALLOW_CALL(...)`**](#ALLOW_CALL) which creates an expectation
 that is valid until the end of the surrounding scope.
-
 
 <A name="NAMED_FORBID_CALL"/>
 
@@ -1216,6 +1242,7 @@ scope would allow the call. [**`RETURN(...)`**](#RETURN),
 is important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1232,19 +1259,19 @@ using expectation = std::unique_ptr<trompeloeil::expectation>;
 TEST(atest)
 {
   C mock_obj;
-  
+
   ALLOW_CALL(mock_obj, func(_));
-  
+
   expectation x1 = NAMED_FORBID_CALL(mock_obj, func(gt(0));
-  
+
   test_function(0, &mock_obj);
-  
+
   expectation x2 = NAMED_FORBID_CALL(mock_obj, func(lt(0));
-  
+
   test_function(1, &mock_obj);
-  
+
   x1.reset(); // allow calls with positive values again
-  
+
   test_function(2, &mock_obj);
 }
 ```
@@ -1277,6 +1304,7 @@ is destroyed can be changed with an optional [**`TIMES(...)`**](#TIMES) clause.
 captured by reference so lifetime management is important.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1292,17 +1320,17 @@ using expectation = std::unique_ptr<trompeloeil::expectation>;
 TEST(atest)
 {
   C mock_obj;
-  
+
   expectation x1 = NAMED_REQUIRE_CALL(mock_obj, func(gt(0));
-  
+
   test_function(0, &mock_obj);
-  
+
   expectation x2 = NAMED_REQUIRE_CALL(mock_obj, func(lt(0));
-  
+
   test_function(1, &mock_obj);
-  
+
   x1.reset(); // The call with positive number must be done here.
-  
+
   test_function(2, &mock_obj);
 }
 ```
@@ -1326,6 +1354,7 @@ object which reports a violation if the
 not destroyed by the time the `expectation` is destroyed.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1340,13 +1369,13 @@ using trompeloeil::deathwatched;
 TEST(atest)
 {
   C* p = new deathwatched<C>();
-  
+
   test_function(0, p); // must not destroy *p
-  
+
   monitor m = NAMED_REQUIRE_DESTRUCTION(*p);
-  
+
   test_function(1, p);
-  
+
   m.reset(); // *p must have been destroyed here
 }
 ```
@@ -1355,7 +1384,7 @@ Above, `p` points to a [`deathwatched`](#deathwatched_type)
 [mock object](#mock_object), meaning that a violation is reported if `*p` is
 destroyed without having a destruction requirement.
 
-The monitor `m` is a requirement that `*p` is destroyed before the 
+The monitor `m` is a requirement that `*p` is destroyed before the
 [`lifetime_monitor`](#lifetime_monitor_type)
 (subtype of [`expectation`](#expectation_type)) held by `m` is destroyed.
 
@@ -1381,6 +1410,7 @@ The number of matches required before the [expectation](#expectation) object
 is destroyed can be changed with an optional [**`TIMES(...)`**](#TIMES) clause.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1394,15 +1424,15 @@ using trompeloeil::lt;
 TEST(atest)
 {
   C mock_obj;
-  {  
+  {
     REQUIRE_CALL(mock_obj, func(gt(0));
-  
+
     test_function(0, &mock_obj);
     // end of scope, requirement must be fulfilled here
   }
   {
     REQUIRE_CALL(mock_obj, func(lt(0));
-  
+
     test_function(1, &mock_obj);
     // end of scope, requirement must be fulfilled here
   }
@@ -1419,7 +1449,6 @@ See also [**`NAMED_REQUIRE_CALL(...)`**](#NAMED_REQUIRE_CALL) which creates an
 [`std::unique_ptr<trompeloeil::expectation>`](#expectation_type) which can be stored in test
 fixtures.
 
-
 <A name="REQUIRE_DESTRUCTION"/>
 
 ### **`REQUIRE_DESTRUCTION(`** *mock_object* **`)`**
@@ -1429,6 +1458,7 @@ a violation if the [**`deathwatched`**](#deathwatched_type)
 [mock object](#mock_object) is not destroyed by the end of the scope.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1442,12 +1472,12 @@ using trompeloeil::deathwatched;
 TEST(atest)
 {
   C* p = new deathwatched<C>();
-  
+
   test_function(0, p); // must not destroy *p
-  
+
   {
     REQUIRE_DESTRUCTION(*p);
-  
+
     test_function(1, p);
     // end of scope, *p must have been destroyed here
   }
@@ -1488,6 +1518,7 @@ This code may alter out-parameters.
 Named local objects accessed here refers to a immutable copies.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1556,10 +1587,10 @@ TEST(atest)
   unsigned offset = 0;
   ALLOW_CALL(mock_obj, func(ANY(unsigned))
     .SIDE_EFFECT(sum += offset + _1);
-    
+
   offset = 2;
   tested_func(&mock_obj);
-  
+
   std::cout << "offset corrected parameter sum=" << sum << "\n";
 }
 ```
@@ -1573,7 +1604,6 @@ Since **`SIDE_EFFECT(...)`** refers to a copy of `offset`, the value of
 See also [**`LR_SIDE_EFFECT(...)`**](#LR_SIDE_EFFECT) which accesses local
 objects by reference.
 
-
 <A name="THROW"/>
 
 ### **`THROW(`** *expr* **`)`**
@@ -1585,10 +1615,11 @@ Used in [expectations](#expectation) to throw after having evaluated every
 `_2`, etc. This code may alter out-parameters. It is not legal to combine
 **`THROW(...)`** with any of [**`LR_THROW(...)`**](#LR_THROW),
 [**`LR_RETURN(...)`**](#LR_RETURN) or [**`RETURN(...)`**](#RETURN).
- 
+
 Named local objects here refers to immutable copies.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1600,10 +1631,10 @@ TEST(atest)
 {
   C mock_obj;
   std::string what="<unknown>";
-  
+
   ALLOW_CALL(mock_obj, func(3))
     .THROW(std::invalid_argument(what));
-  
+
   what = "";
   tested_func(&mock_obj);
 }
@@ -1613,7 +1644,6 @@ Above, **`THROW(...)`** will refer to a copy of the string `what` with the value
 `"<unknown>"` if a matching call is made from within `tested_func(...)`
 
 See also [**`LR_THROW(...)`**](#LR_THROW) which accesses copies of local objects.
-
 
 <A name="TIMES"/>
 
@@ -1642,6 +1672,7 @@ If the maximum number of matching calls is exceeded, a violation is reported.
 [**`NAMED_REQUIRE_CALL(...)`**](#NAMED_REQUIRE_CALL).
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1654,10 +1685,10 @@ using trompeloeil::_;
 TEST(atest)
 {
   C mock_obj;
-  
+
   REQUIRE_CALL(mock_obj, func(_))
     .TIMES(2, 5);
-  
+
   tested_func(&mock_obj);
 ```
 
@@ -1684,6 +1715,7 @@ and they are tried in the order until one has failed, or they all have passed.
 Named local objects here refers to immutable copies.
 
 Example:
+
 ```Cpp
 class C
 {
@@ -1698,12 +1730,12 @@ TEST(atest)
   C mock_obj;
 
   std::string str = "string";
-  
+
   REQUIRE_CALL(mock_obj, func(_,_))
     .WITH(std::string(_1, _2) == str);
-  
+
   str = ""; // does not alter the copy in the expectation above.
-  
+
   tested_func(buff, &mock_obj);
 }
 ```
@@ -1947,6 +1979,7 @@ protected:
 };
 }
 ```
+
 See "[Writing custom tracers](CookBook.md/#custom_tracer)" in the
 [Cook Book](CookBook.md) for an example.
 
@@ -2005,6 +2038,7 @@ used, this is true if the maximum number of calls has been reached.
 
   /* mock_obj.func();*/ // would cause "unexpected call" error.
 ```
+
 ### <A name="get_lock"/> `trompeloeil::get_lock()`
 
 Get the global
@@ -2030,7 +2064,7 @@ Null check that works for all types. If `T` is not comparable with
 ### <A name="make_matcher"/>`trompeloeil::make_matcher<Type>(...)`
 
 ```Cpp
-template <typename Type, typename Predicate, typename Printer, typename ... T> 
+template <typename Type, typename Predicate, typename Printer, typename ... T>
 auto make_matcher(Predicate predicate /* bool (Type& value, T const& ...) */,
                   Printer printer     /* void (std::ostream&, T const& ...) */,
                   T&& ... stored_values);
@@ -2050,7 +2084,6 @@ value to check for, and each of the stored values `T&&...` in order as
 `printer` is a callable object, typically a lambda, that accepts an
 [`ostream&`](http://en.cppreference.com/w/cpp/io/basic_ostream) and the
 stored values `T&&...` in order as `const&`.
-
 
 Examples are found in the Cook Book under
 [Writing custom matchers](CookBook.md/#custom_matchers)


### PR DESCRIPTION
I have started using Visual Studio Code for software development,
mainly because the Markdown Support extension in CLion 2018.1
shipped with critical defects.

One of the extensions I found was `markdownlint`, which is a linter
for Markdown documents.  Details,

Site: <https://github.com/DavidAnson/vscode-markdownlint>
Version: 0.14.1

This pull request is the result of applying `markdownlint` to the
current documentation for Trompeloeil.  Doubtless a few other
improvements to the documentation may be made, but this is
a start.

## Markdownlint configuration

Here is the configuration I used for `markdownlint`, placed in my
User Settings

```json
{
    "markdownlint.config": {
        "MD013": false,
        "MD024": false,
        "MD025": false,
        "MD026": {
            "punctuation": ".,;:!"
        },
        "MD033": {
            "allowed_elements": ["a"]
        }
    }
}
```

Short description of each line,

- MD013: Do not enforce a line length limit.
- MD024: Allow headers with the same content. [Mainly for my blog.]
- MD025: Allow multiple top-level headers. [Mainly for my blog.]
- MD026: Accept question mark as trailing punctuation (for FAQ).
- MD033: Allow HTML anchor in documentation.

This could be refined into a settings file in the `docs/` directory
at a future time.