### PR TITLE
Enabled destructor override warning for Clang 5.0 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,6 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
              " -Wno-weak-vtables"
              " -Wno-exit-time-destructors"
              " -Wno-global-constructors")
-      CHECK_CXX_COMPILER_FLAG("-Wno-inconsistent-missing-destructor-override"
-                              W_MISSING_DTOR_OVERRIDE)
-      if (W_MISSING_DTOR_OVERRIDE)
-        string(CONCAT
-               WARN_FLAGS
-               " -Wno-inconsistent-missing-destructor-override")
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
       string(CONCAT
              WARN_FLAGS

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+	* Enabled destructor override warning for Clang 5.0 or later
 
 	* Updated unit test framework to Catch 2.2.1.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-	* Enabled destructor override warning for Clang 5.0 or later
+	* Enabled destructor override warning in self_test build for Clang 5.0 or later
 
 	* Updated unit test framework to Catch 2.2.1.
 


### PR DESCRIPTION
With the `override` specifier added to the destructors of
classes `lifetime_monitor` and `call_matcher`, there is
no longer any reason to disable the corresponding warning
from Clang 5.0 or later.