### PR TITLE
fix c++11 msvc support

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -74,11 +74,13 @@
 
 #define TROMPELOEIL_GCC_VERSION 0
 
-/* MSVC is an amalgam of C++ versions, with no provision to
- * force C++11 mode.  It also has a __cplusplus macro stuck at 199711L.
- * Assume the C++14 code path.
- */
-#define TROMPELOEIL_CPLUSPLUS 201401L
+#if _MSC_VER > 1910
+#  define TROMPELOEIL_CPLUSPLUS 201401L
+#elif _MSC_VER == 1900
+#  define TROMPELOEIL_CPLUSPLUS 201103L
+#else
+#  error requires Visual Studio 2015 RC or later
+#endif
 
 #endif
 


### PR DESCRIPTION
Hi,
I have some problems using the trompeloeil in the Visual Studio 2015, it does not [support full С++14](https://msdn.microsoft.com/en-us/library/hh567368.aspx).
Therefore, I think in Visual Studio 2015 need use С++ 11 API trompeloeil.

Maybe it's worth adding  test in Appveyor CI with Visual Studio 2015 and Visual Studio 2017.
