### PR TITLE
CI Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .*
-cmake-build*
+*build*
 *~
 a.out
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,37 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - g++-6
+            - clang-3.5
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+      env:
+        - COMPILER="clang++-3.5" SANITIZE=true
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - g++-6
+            - clang-3.6
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+      env:
+        - COMPILER="clang++-3.6" SANITIZE=true
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7
-            - ppa:george-edison55/cmake-3.x
           packages:
             - g++-6
             - clang-3.7
@@ -33,7 +62,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.8
+            - llvm-toolchain-precise-3.8
           packages:
             - g++-6
             - clang-3.8
@@ -41,14 +70,14 @@ matrix:
             - libelf-dev
             - libdw-dev
       env:
-        - COMPILER="clang++-3.8" CXXFLAGS="-std=c++14" SANITIZE=true
+        - COMPILER="clang++-3.8" SANITIZE=true
 
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
+            - llvm-toolchain-trusty-3.9
           packages:
             - g++-6
             - clang-3.9
@@ -190,19 +219,19 @@ matrix:
         - COMPILER="g++-8" SANITIZE=true
 
     - os: osx
-      osx_image: xcode9
-      compiler: clang
-      env:
-        - COMPILER="clang++" SANITIZE=false
-
-    - os: osx
-      osx_image: xcode8
-      compiler: clang
-      env:
-        - COMPILER="clang++" SANITIZE=false
-
-    - os: osx
       osx_image: xcode7.3
+      compiler: clang
+      env:
+        - COMPILER="clang++" SANITIZE=false
+
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+      env:
+        - COMPILER="clang++" SANITIZE=false
+
+    - os: osx
+      osx_image: xcode9.3
       compiler: clang
       env:
         - COMPILER="clang++" SANITIZE=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,6 +241,7 @@ install:
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       which cmake || brew install cmake
     fi
+  - JOBS=2 # Travis machines have 2 cores.
 
 before_script:
   - CXX=${COMPILER} CXXFLAGS=${CXXFLAGS} ./check_errors.sh ||
@@ -250,13 +251,13 @@ before_script:
     fi
   - mkdir build && cd build
   - CXX=${COMPILER} cmake -DCXX_STANDARD="${CXX_STANDARD}" -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
-  - cmake --build . --target self_test --config Debug
+  - cmake --build . --target self_test --config Debug -- -j${JOBS}
 
 script:
-  - ctest -V --output-on-failure -C Debug
+  - ctest -V --output-on-failure -C Debug -j${JOBS}
 
 after_success:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      cmake --build . --target run_coverage --config Debug
+      cmake --build . --target run_coverage --config Debug -- -j${JOBS}
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,14 @@ matrix:
             - libelf-dev
             - libdw-dev
       env:
-        - COMPILER="clang++-3.7"
-      before_script:
+        - COMPILER="clang++-3.7" SANITIZE=true
+      before_install:
         # The clang runtime for the address sanitizer is missing from the
         # apt, hence the downloaded tarballs.
 
         - wget http://releases.llvm.org/3.7.1/clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - tar -xvf clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - sudo cp -n clang+llvm-3.7.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.7.1/lib/linux/*.a /usr/lib/llvm-3.7/lib/clang/3.7.1/lib/linux/
-        - CXX=${COMPILER} ./check_errors.sh
-        - mkdir build && cd build
-        - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=true ..
-        - make -j 4 VERBOSE=1 self_test kcov
 
     - os: linux
       addons:
@@ -60,8 +56,8 @@ matrix:
             - libelf-dev
             - libdw-dev
       env:
-        - COMPILER="clang++-3.9"
-      before_script:
+        - COMPILER="clang++-3.9" SANITIZE=true
+      before_install:
         # Unlike with clang++-3.7, the runtime libraries exists with 3.9,
         # but still doesn't work because of gold linker version incompatibility.
         # The tarball download takes care of that.
@@ -69,10 +65,6 @@ matrix:
         - wget http://releases.llvm.org/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - tar -xvf clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         - sudo cp clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-14.04/lib/clang/3.9.1/lib/linux/*.a /usr/lib/llvm-3.9/lib/clang/3.9.1/lib/linux/
-        - CXX=${COMPILER} ./check_errors.sh
-        - mkdir build && cd build
-        - CXX=${COMPILER} cmake -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=true ..
-        - make -j 4 VERBOSE=1 self_test kcov
 
     - os: linux
       addons:
@@ -224,18 +216,18 @@ install:
 before_script:
   - CXX=${COMPILER} CXXFLAGS=${CXXFLAGS} ./check_errors.sh ||
     FAILURES="$?" && if [[ ${CXX_STANDARD} == "11" && ${FAILURES} != "4" ]]; then
-      echo "Expected four failures from C++11 build, got " ${FAILURES} ;
-      exit 1 ;
+      echo "Expected four failures from C++11 build, got " ${FAILURES};
+      exit 1;
     fi
   - mkdir build && cd build
   - CXX=${COMPILER} cmake -DCXX_STANDARD="${CXX_STANDARD}" -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
-  - make VERBOSE=1 self_test
+  - cmake --build . --target self_test --config Debug
 
 script:
-  make run_self_test
+  - ctest -V --output-on-failure -C Debug
 
 after_success:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      make VERBOSE=1 run_coverage
+      cmake --build . --target run_coverage --config Debug
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ include(CheckCXXCompilerFlag)
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/trompeloeil/trompeloeil-config-version.cmake"
   VERSION 31
-  COMPATIBILITY AnyNewerVersion)
+  COMPATIBILITY AnyNewerVersion
+)
 
 if (CXX_STANDARD MATCHES "11")
   set(CMAKE_CXX_STANDARD 11)
@@ -72,18 +73,8 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 
-    # kcov is only available on Linux platforms.
-	ExternalProject_Add(
-	  kcov
-	  GIT_REPOSITORY
-		https://github.com/simonkagstrom/kcov
-	  GIT_TAG
-		v34
-	  INSTALL_DIR
-		${CMAKE_CURRENT_BINARY_DIR}/kcov
-	  CMAKE_ARGS
-		"-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/kcov"
-	  )
+  # Enable verbose output from Makefile builds.
+  set(CMAKE_VERBOSE_MAKEFILE ON)
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       string(CONCAT
@@ -143,100 +134,8 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
 
   endif() # MSVC
 
-  add_executable(
-    self_test
-    EXCLUDE_FROM_ALL
-    test/compiling_tests.cpp
-    test/compiling_tests_11.cpp
-    test/compiling_tests_14.cpp
-  )
-
-  target_include_directories(
-    self_test
-    PRIVATE
-    ${CATCH_DIR}
-  )
-
-  if (SANITIZE)
-    set_target_properties(
-      self_test
-      PROPERTIES
-        LINK_FLAGS
-          "${SSAN} -fuse-ld=gold"
-        COMPILE_FLAGS
-          ${SSAN}
-    )
-  endif()
-
-  target_link_libraries(
-    self_test
-    PUBLIC
-      trompeloeil
-  )
-
-  add_executable(
-    thread_terror
-    EXCLUDE_FROM_ALL
-    test/thread_terror.cpp
-    )
-
-  target_link_libraries(
-    thread_terror
-    PUBLIC
-      trompeloeil
-      pthread
-  )
-
-  if (SANITIZE)
-    set_target_properties(
-      thread_terror
-      PROPERTIES
-        LINK_FLAGS
-          ${TSAN}
-        COMPILE_FLAGS
-          ${TSAN}
-    )
-  endif()
-
-  # Shameless hack to get target to work on Windows.
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-
-    add_custom_target(
-      run_self_test
-      COMMAND
-        ${CMAKE_CURRENT_BINARY_DIR}/self_test
-      DEPENDS
-        self_test
-    )
-
-  else()
-
-    add_custom_target(
-      run_self_test
-      COMMAND
-        ${CMAKE_CURRENT_BINARY_DIR}/Debug/self_test
-      DEPENDS
-        self_test
-    )
-
-  endif()
-
-  if(TRAVIS_JOB_ID)
-    set(COVERALLS_FLAG "--coveralls-id=${TRAVIS_JOB_ID}")
-  endif()
-
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-
-    add_custom_target(
-      run_coverage
-      COMMAND
-        ${CMAKE_CURRENT_BINARY_DIR}/kcov/bin/kcov --skip-solibs --include-pattern=trompeloeil.hpp ${COVERALLS_FLAG} ./coverage ${CMAKE_CURRENT_BINARY_DIR}/self_test
-      DEPENDS
-        self_test
-        kcov
-    )
-
-  endif()
+  enable_testing()
+  add_subdirectory(test)
 
 endif() # MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug
 
@@ -255,6 +154,7 @@ install(
   DESTINATION
     lib/cmake/trompeloeil
 )
+
 install(
   FILES
     trompeloeil-config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
     endif()
     file(
       DOWNLOAD
-        https://raw.githubusercontent.com/catchorg/Catch2/v2.2.1/single_include/catch.hpp  ${CATCH_DIR}/catch.hpp
+        https://raw.githubusercontent.com/catchorg/Catch2/v2.2.2/single_include/catch.hpp  ${CATCH_DIR}/catch.hpp
       STATUS
         status
       LOG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
   if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
     add_compile_options(/W4)
+    add_compile_options(/WX)
     add_compile_options(/bigobj)
 
     check_cxx_compiler_flag(/permissive HAS_PERMISSIVE_FLAG)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 	* Enabled destructor override warning in self_test build for Clang 5.0 or later
 
-	* Updated unit test framework to Catch 2.2.1.
+	* Updated unit test framework to Catch 2.2.2.
 
 	* Fix issue #69: work around C4702 warning from VS Release builds.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,17 +4,17 @@
 
 	* Updated unit test framework to Catch 2.2.2.
 
+	* Fix issue #87: C4355 warning from VS Release builds.  Thanks @Neargye
+
 	* Fix issue #69: work around C4702 warning from VS Release builds.
 
 	* Fix issue #88: work around C2066 error from VS 2017 15.7.1.
-
 
 v31 2018-05-11
 
 	* Issue #83: Add AppVeyor support for VS 2015 and VS 2017
 
 	* Fix issue #82: restore compilation with VS 2015.
-
 
 v30 2018-04-02
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 	* Updated unit test framework to Catch 2.2.2.
 
+	* Worked around clang++-6 bugs 38010 and 38033
+
 	* Improve support for compiler modes:
 	  GCC and Clang: -std=c++17; MSVC: /std:c++17
 	  GCC and Clang: -std=c++2a; MSVC: /std:c++latest

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@
 
 	* Updated unit test framework to Catch 2.2.2.
 
+	* Improve support for compiler modes:
+	  GCC and Clang: -std=c++17; MSVC: /std:c++17
+	  GCC and Clang: -std=c++2a; MSVC: /std:c++latest
+
 	* Fix issue #87: C4355 warning from VS Release builds.  Thanks @Neargye
 
 	* Fix issue #69: work around C4702 warning from VS Release builds.

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@
 
 	* Updated unit test framework to Catch 2.2.1.
 
+	* Fix issue #69: work around C4702 warning from VS Release builds.
+
+	* Fix issue #88: work around C2066 error from VS 2017 15.7.1.
+
+
 v31 2018-05-11
 
 	* Issue #83: Add AppVeyor support for VS 2015 and VS 2017

--- a/Makefile.travis
+++ b/Makefile.travis
@@ -1,8 +1,0 @@
-all: self_test
-	./self_test
-
-clean:
-	rm ./self_test
-
-self_test: compiling_tests.cpp trompeloeil.hpp
-	$(CXX) $(CXXFLAGS) -Werror $< -o $@

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ image:
 
 configuration:
   - Debug
+  - Release
 
 environment:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ version: "{branch} #{build}"
 image:
   - Visual Studio 2017
 
+configuration:
+  - Debug
+
 environment:
   matrix:
     - GENERATOR: "Visual Studio 14 2015 Win64"
@@ -16,8 +19,7 @@ before_build:
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=Debug ..
 
 build_script:
-- cmd: >-
-    cmake --build . --target self_test
+  - cmake --build . --target self_test --config %CONFIGURATION%
 
 test_script:
-- cmd: cmake --build . --target run_self_test
+  - ctest -V --output-on-failure -C %CONFIGURATION%

--- a/docs/Backward.md
+++ b/docs/Backward.md
@@ -36,7 +36,7 @@ compliance with the features available in the C\+\+11 standard without
 compiler extensions.  (Indeed, it might be much worse: you might have
 a project forced to use `g++-4.8.3` with further constraints.)
 
-To allow you consider Trompeloeil as your mock object framework
+To allow you to consider Trompeloeil as your mock object framework
 for a project with these constraints, we have back ported Trompeloeil to
 `g++-4.8.4` (C\+\+11, `libstdc++-v3`) with an API that may be used with
 a C\+\+11 dialect selected.  The C\+\+11 API remains supported when a C\+\+14

--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -891,7 +891,7 @@ public:
 void test()
 {
   Mock m;
-  ALLOW_CALL(m, func(1);          // int version any number of times
+  ALLOW_CALL(m, func(1));         // int version any number of times
   REQUIRE_CALL(m, func(nullptr)); // const char * version exactly once
   func(&m);
   // expectations must be met before end of scope

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1586,7 +1586,7 @@ Above, `p` points to a [`deathwatched`](#deathwatched_type)
 [mock object](#mock_object), meaning that a violation is reported if `*p` is
 destroyed without having a destruction requirement.
 
-[**`REQUIRE_DESTRUCTION(...)`**] in the local scope puts a requirement on
+**`REQUIRE_DESTRUCTION(...)`** in the local scope puts a requirement on
 `*p` that it must be destroyed by the end of the scope.
 
 It is thus a violation if the first call to `test_function(...)` destroys

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -709,9 +709,7 @@ namespace trompeloeil
       unsigned long line,
       std::string const &call) = 0;
   protected:
-    tracer()
-    noexcept
-      : previous{set_tracer(this)} {}
+    tracer() = default;
     tracer(tracer const&) = delete;
     tracer& operator=(tracer const&) = delete;
     virtual
@@ -720,7 +718,7 @@ namespace trompeloeil
       set_tracer(previous);
     }
   private:
-    tracer* previous = nullptr;
+    tracer* previous = set_tracer(this);
   };
 
   class stream_tracer : public tracer

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -2497,7 +2497,18 @@ namespace trompeloeil
   R
   default_return()
   {
-    return default_return_t<R>::value();
+    /* Work around VS 2017 15.7.x C4702 warning by
+     * enclosing the operation in an otherwise
+     * unnecessary try/catch block.
+     */
+    try
+    {
+      return default_return_t<R>::value();
+    }
+    catch (...)
+    {
+      throw;
+    }
   }
 
 
@@ -2933,7 +2944,18 @@ namespace trompeloeil
     F& func,
     P& params)
   {
-    return agent.trace_return(func(params));
+    /* Work around VS 2017 15.7.x C4702 warning by
+     * enclosing the operation in an otherwise
+     * unnecessary try/catch block.
+     */
+    try
+    {
+      return agent.trace_return(func(params));
+    }
+    catch (...)
+    {
+      throw;
+    }
   }
 
   template <typename Sig, typename T>
@@ -3207,7 +3229,18 @@ namespace trompeloeil
       template <typename T>
       R operator()(T& p)
       {
-        h(p);
+        /* Work around VS 2017 15.7.x C4702 warning by
+         * enclosing the operation in an otherwise
+         * unnecessary try/catch block.
+         */
+        try
+        {
+          h(p);
+        }
+        catch (...)
+        {
+          throw;
+        }
         return R();
       }
 
@@ -4091,7 +4124,8 @@ namespace trompeloeil
                                                                                \
     /* Work around parsing bug in VS 2015 when a "complex" */                  \
     /* decltype() appears in a trailing return type. */                        \
-    using trompeloeil_sig_t = sig;                                             \
+    /* Further, work around C2066 defect in VS 2017 15.7.1. */                 \
+    using trompeloeil_sig_t = typename ::trompeloeil::identity_type<sig>::type;\
                                                                                \
     using trompeloeil_call_params_type_t =                                     \
       ::trompeloeil::call_params_type_t<sig>;                                  \

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -2,7 +2,7 @@
  * Trompeloeil C++ mocking framework
  *
  * Copyright Björn Fahller 2014-2018
- * Copyright (C) 2017 Andrew Paxie
+ * Copyright (C) 2017, 2018 Andrew Paxie
  *
  *  Use, modification and distribution is subject to the
  *  Boost Software License, Version 1.0. (See accompanying
@@ -47,38 +47,59 @@
 
 #if defined(__clang__)
 
-#define TROMPELOEIL_CLANG 1
-#define TROMPELOEIL_GCC 0
-#define TROMPELOEIL_MSVC 0
+#  define TROMPELOEIL_CLANG 1
+#  define TROMPELOEIL_GCC 0
+#  define TROMPELOEIL_MSVC 0
 
-#define TROMPELOEIL_GCC_VERSION 0
+#  define TROMPELOEIL_GCC_VERSION 0
 
-#define TROMPELOEIL_CPLUSPLUS __cplusplus
+#  define TROMPELOEIL_CPLUSPLUS __cplusplus
 
 #elif defined(__GNUC__)
 
-#define TROMPELOEIL_CLANG 0
-#define TROMPELOEIL_GCC 1
-#define TROMPELOEIL_MSVC 0
+#  define TROMPELOEIL_CLANG 0
+#  define TROMPELOEIL_GCC 1
+#  define TROMPELOEIL_MSVC 0
 
-#define TROMPELOEIL_GCC_VERSION                                                \
+#  define TROMPELOEIL_GCC_VERSION \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
-#define TROMPELOEIL_CPLUSPLUS __cplusplus
+#  define TROMPELOEIL_CPLUSPLUS __cplusplus
 
 #elif defined(_MSC_VER)
 
-#define TROMPELOEIL_CLANG 0
-#define TROMPELOEIL_GCC 0
-#define TROMPELOEIL_MSVC 1
+#  define TROMPELOEIL_CLANG 0
+#  define TROMPELOEIL_GCC 0
+#  define TROMPELOEIL_MSVC 1
 
-#define TROMPELOEIL_GCC_VERSION 0
+#  define TROMPELOEIL_GCC_VERSION 0
 
-/* MSVC is an amalgam of C++ versions, with no provision to
- * force C++11 mode.  It also has a __cplusplus macro stuck at 199711L.
- * Assume the C++14 code path.
- */
-#define TROMPELOEIL_CPLUSPLUS 201401L
+#  if defined(_MSVC_LANG)
+
+    // Compiler is at least Microsoft Visual Studio 2015 Update 3.
+#    define TROMPELOEIL_CPLUSPLUS _MSVC_LANG
+
+#  else /* defined(_MSVC_LANG) */
+
+    /*
+     * This version of Microsoft Visual C++ is released
+     * in a version of Microsoft Visual Studio between
+     * 2015 RC and less than 2015 Update 3.
+     *
+     * It is an amalgam of C++ versions, with no provision
+     * to specify C++11 mode.
+     *
+     * It also has a __cplusplus macro stuck at 199711L with
+     * no way to change it, such as /Zc:__cplusplus.
+     *
+     * Assume the C++14 code path, but don't promise that it is a
+     * fully conforming implementation of C++14 either.
+     * Hence a value of 201401L, which less than 201402L,
+     * the standards conforming value of __cplusplus.
+     */
+#    define TROMPELOEIL_CPLUSPLUS 201401L
+
+#  endif /* !defined(_MSVC_LANG) */
 
 #endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,91 @@
+﻿# self_test
+add_executable(
+  self_test
+  EXCLUDE_FROM_ALL
+  compiling_tests.cpp
+  compiling_tests_11.cpp
+  compiling_tests_14.cpp
+)
+
+target_include_directories(
+  self_test
+  PRIVATE
+  ${CATCH_DIR}
+)
+
+target_link_libraries(
+  self_test
+  PUBLIC
+    trompeloeil
+)
+
+if (SANITIZE)
+  set_target_properties(
+    self_test
+    PROPERTIES
+      LINK_FLAGS
+        "${SSAN} -fuse-ld=gold"
+      COMPILE_FLAGS
+        ${SSAN}
+  )
+endif()
+
+add_test(NAME run_self_test COMMAND self_test)
+
+# thread_terror
+add_executable(
+  thread_terror
+  EXCLUDE_FROM_ALL
+  thread_terror.cpp
+)
+
+target_link_libraries(
+  thread_terror
+  PUBLIC
+    trompeloeil
+    pthread
+)
+
+if (SANITIZE)
+  set_target_properties(
+    thread_terror
+    PROPERTIES
+      LINK_FLAGS
+        ${TSAN}
+      COMPILE_FLAGS
+        ${TSAN}
+  )
+endif()
+
+#add_test(NAME run_thread_terror COMMAND thread_terror)
+
+# coverage
+if((CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (UNIX AND NOT APPLE))
+
+  # kcov is only available on Linux platforms.
+  ExternalProject_Add(
+    kcov
+    GIT_REPOSITORY
+      https://github.com/simonkagstrom/kcov
+    GIT_TAG
+      v34
+    INSTALL_DIR
+      ${CMAKE_CURRENT_BINARY_DIR}/kcov
+    CMAKE_ARGS
+      "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/kcov"
+    )
+
+  if(TRAVIS_JOB_ID)
+    set(COVERALLS_FLAG "--coveralls-id=${TRAVIS_JOB_ID}")
+  endif()
+
+  add_custom_target(
+    run_coverage
+    COMMAND
+      ${CMAKE_CURRENT_BINARY_DIR}/kcov/bin/kcov --skip-solibs --include-pattern=trompeloeil.hpp ${COVERALLS_FLAG} ./coverage ${CMAKE_CURRENT_BINARY_DIR}/self_test
+    DEPENDS
+      self_test
+      kcov
+  )
+
+endif()


### PR DESCRIPTION
Example of how I would like to improve ci. This is a dump of my experience, so that you can make a review and add criticism or suggestions.

ChangeLog:

* Merge master
* Add *build* to gitignore (ci use "build" folder)
* Replacing own testing scripts to cmake ctest
* Updated unit test framework to Catch 2.2.2.
* Warning as error for msvc
* Debug/Release configuration for msvc (test cases as in https://github.com/rollbear/trompeloeil/issues/69)
* kcov more for test, using only on Linux
* Clean-up
* Add more compiler image for ci (clang3.5, clang3.6 in readme says work with it, update xcode image)
* Add parallel build travis
