### PR TITLE
Fix issue #87: C4355 from Visual Studio release builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+	* Fix issue #87: C4355 warning from VS Release builds.  Thanks @Neargye
+
 	* Fix issue #69: work around C4702 warning from VS Release builds.
 
 	* Fix issue #88: work around C2066 error from VS 2017 15.7.1.

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -709,9 +709,7 @@ namespace trompeloeil
       unsigned long line,
       std::string const &call) = 0;
   protected:
-    tracer()
-    noexcept
-      : previous{set_tracer(this)} {}
+    tracer() = default;
     tracer(tracer const&) = delete;
     tracer& operator=(tracer const&) = delete;
     virtual
@@ -720,7 +718,7 @@ namespace trompeloeil
       set_tracer(previous);
     }
   private:
-    tracer* previous = nullptr;
+    tracer* previous = set_tracer(this);
   };
 
   class stream_tracer : public tracer


### PR DESCRIPTION
With `/Wall` for a `Debug|x86` build I was able to reproduce the C4355 warning
and then resolve it with the code change in this pull request.