### PR TITLE
Move mock

### DIFF
--- a/compilation_errors/illegal_move_mock.cpp
+++ b/compilation_errors/illegal_move_mock.cpp
@@ -1,0 +1,33 @@
+/*
+ * Trompeloeil C++ mocking framework
+ *
+ * Copyright Björn Fahller 2019
+ *
+ *  Use, modification and distribution is subject to the
+ *  Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * Project home: https://github.com/rollbear/trompeloeil
+ */
+
+// make a mock object movable, see:
+
+#include <trompeloeil.hpp>
+
+
+struct M
+{
+  MAKE_MOCK1(f, void(int));
+};
+
+template <typename T>
+T ident(T t)
+{
+  return t;
+}
+
+int main()
+{
+  auto obj = ident(M{});
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,6 +18,7 @@
 - Q. [Can I negate the effect of a matcher?](#negate_matcher)
 - Q. [Can I check if an expectation is fulfilled?](#query_expectation)
 - Q. [What does it mean to mix **`IN_SEQUENCE`** and **`TIMES`**?](#sequence_times)
+- Q. [Why are mock objects not move constructible?](#move_constructible)
 
 ## <A name="why_name"/>Q. Why a name that can neither be pronounced nor spelled?
 
@@ -502,3 +503,23 @@ so everything is good.
 The current step in the sequence is `mock.foo2()`. Is is satisfied and
 saturated, so the sequence object must move to the next step. The next step is
 `mock.foo3()`, which is a mismatch, so a sequence violation is reported.
+
+### <A name="move_constructible"/>
+
+Q. Why are mock objects not move constructible?
+
+Because a move is potentially dangerous in non-obvious ways. If a mock object is
+moved, the actions associated with an expectation
+([**`.WITH()`**](reference.md/#WITH),
+ [**`.SIDE_EFFECT()`**](reference.md/#SIDE_EFFECT),
+ [**`.RETURN()`**](reference.md/#RETURN),
+ [**`.THROW()`**](reference.md/#THROW)) and their
+ `LR_` versions, are *not* moved. If they refer to data members stored in a
+ moved mock object, they will refer to dead data. This is an accepted const
+ in normal C++ code, but since the effect is hidden under the macros,
+ it is better to play safe.
+ 
+With that said, you can explicitly make mock objects movable, if you want to.
+See:
+
+

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -520,6 +520,7 @@ moved, the actions associated with an expectation
  it is better to play safe.
  
 With that said, you can explicitly make mock objects movable, if you want to.
-See:
+See: [**`trompeloeil_movable_mock`**](reference.md/#movable_mock).
+
 
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,7 +54,7 @@
   - [`trompeloeil::stream_tracer`](#stream_tracer)
   - [`tropmeloeil::tracer`](#tracer_type)
   - [`trompeloeil::typed_matcher<T>`](#typed_matcher)
-  - [`trempoleil_movable_type`](#movable_type)
+  - [`trompeloeil_movable_type`](#movable_mock)
 - [Functions and Function Templates](#functions)
   - [`trompeloeil::expectation::is_satisfied()`](#is_satisfied)
   - [`trompeloeil::expectation::is_saturated()`](#is_saturated)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,7 +54,6 @@
   - [`trompeloeil::stream_tracer`](#stream_tracer)
   - [`tropmeloeil::tracer`](#tracer_type)
   - [`trompeloeil::typed_matcher<T>`](#typed_matcher)
-  - [`trompeloeil_movable_type`](#movable_mock)
 - [Functions and Function Templates](#functions)
   - [`trompeloeil::expectation::is_satisfied()`](#is_satisfied)
   - [`trompeloeil::expectation::is_saturated()`](#is_saturated)
@@ -64,6 +63,8 @@
   - [`trompeloeil::print(std::ostream&, T const&)`](#print)
   - [`trompeloeil::set_reporter(...)`](#set_reporter)
   - [`trompeloeil::sequence::is_completed()`](#is_completed)
+- [Constants](#constants)  
+  - [`trompeloeil_movable_mock`](#movable_mock)
 
 ## <A name="notions"/>Notions
 
@@ -2131,66 +2132,6 @@ type. It inherits from [`trompeloeil::matcher`](#matcher_type).
 See "[Writing custom matchers](CookBook.md/#custom_matchers)" in the
 [Cook Book](CookBook.md) for examples.
 
-### <A named="movable_mock"/> `trompeloeil_movable_mock`
-
-By adding a public member type `trompeloeil_movable_mock` to your mock
-struct/class, you make it move constructible. Note that when a mock object is
-moved, any current expectations will be taken over by the newly constructed
-mock object, but the implicitly created lambdas associated with
-[**`.WITH()`**](reference.md/#WITH),
-[**`.SIDE_EFFECT()`**](reference.md/#SIDE_EFFECT),
-[**`.RETURN()`**](reference.md/#RETURN) and
-[**`.THROW()`**](reference.md/#THROW) and their `**LR_**` counter parts, will
-not themselves be moved. This means that if they refer to member variables
-in the mock objects, they will refer to dead store after the move. Also, keep
-in mind the lifetime of expectations. If you move a mock object that has
-active expectations, they should almost certainly be
-[**`NAMED_REQUIRE_CALL()`**](reference.md/#NAMED_REQUIRE_CALL),
-[**`NAMED_ALLOW_CALL()`**](reference.md/#NAMED_ALLOW_CALL) or
-[**`NAMED_FORBID_CALL()`**](reference.md/#NAMED_FORBID_CALL).
-
-```Cpp
-class immobile
-{
-public:
-  MAKE_MOCK1(func, void(int));
-};
-
-class movable
-{
-public:
-  int i = 0;
-  struct trompeloeil_movable_mock{}; // allow move construction
-  MAKE_MOCK1(func, void(int));
-};
-
-template <typename T>
-T transfer(T t)
-{
-  return t;
-}
-
-test(...)
-{
-  auto m = transfer(immobile{}); // compilation error
-  ...
-}
-test(...)
-{
-  movable m;
-  auto e = NAMED_REQUIRE_CALL(m, func(3));
-  auto mm = transfer(std::move(m)); // OK, e now belongs to mm.
-  ...
-}
-test(...)
-{
-  movable m{3};
-  auto e = NAMED_REQUIRE_CALL(m, func(_))
-    .LR_WITH(_1 == m.i);
-  auto mm = transfer(std::move(m)); // Danger! e still refers to m.i.
-  ...
-}
-``` 
 
 ## <A name="functions"/>Functions
 
@@ -2339,3 +2280,75 @@ void test()
   assert(seq.is_completed());  // now sequence is completed
 }
 ```
+
+## <A name="constants"/>Constants
+
+### <A name="movable_mock"/> `trompeloeil_movable_mock`
+
+By adding a static constexpr bool member `trompeloeil_movable_mock` with the
+value `true` to your mock struct/class, you make it move constructible. Note
+that when a mock object is moved, any current expectations will be taken over
+by the newly constructed mock object, but note also that if the implicitly
+created lambdas associated with
+[**`.WITH()`**](reference.md/#WITH),
+[**`.SIDE_EFFECT()`**](reference.md/#SIDE_EFFECT),
+[**`.RETURN()`**](reference.md/#RETURN) and
+[**`.THROW()`**](reference.md/#THROW) and their `**LR_**` counter parts, refers
+to member variables in the mock objects, they will continue to refer the old
+moved from object.
+ 
+Also, keep in mind the lifetime of expectations. If the lifetime of an
+expectation is associated with the life of the moved-from object, your test
+will likely fail, since the expectation object would then be destroyed before it
+has been satisfied. Using
+[**`NAMED_REQUIRE_CALL()`**](reference.md/#NAMED_REQUIRE_CALL),
+[**`NAMED_ALLOW_CALL()`**](reference.md/#NAMED_ALLOW_CALL) or
+[**`NAMED_FORBID_CALL()`**](reference.md/#NAMED_FORBID_CALL) can help, since
+they make the expectation life times more visible.
+
+```Cpp
+class immobile
+{
+public:
+  MAKE_MOCK1(func, void(int));
+};
+
+class movable
+{
+public:
+  int i = 0;
+  
+  static constexpr bool trompeloeil_movable_mock = true;
+  // allow move construction
+  
+  MAKE_MOCK1(func, void(int));
+};
+
+template <typename T>
+T transfer(T t)
+{
+  return t;
+}
+
+test(...)
+{
+  auto m = transfer(immobile{}); // compilation error
+  ...
+}
+test(...)
+{
+  movable m;
+  auto e = NAMED_REQUIRE_CALL(m, func(3));
+  auto mm = transfer(std::move(m));
+   // A call to mm.func() now satisfies e
+  ...
+}
+test(...)
+{
+  movable m{3};
+  auto e = NAMED_REQUIRE_CALL(m, func(_))
+    .LR_WITH(_1 == m.i);
+  auto mm = transfer(std::move(m)); // Danger! e still refers to m.i.
+  ...
+}
+``` 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -3886,8 +3886,8 @@ template <typename T>
       active.decommission();
       saturated.decommission();
     }
-    call_matcher_list<Sig> active;
-    call_matcher_list<Sig> saturated;
+    call_matcher_list<Sig> active{};
+    call_matcher_list<Sig> saturated{};
   };
 
   template <typename Sig>
@@ -3905,8 +3905,8 @@ template <typename T>
       active.decommission();
       saturated.decommission();
     }
-    call_matcher_list<Sig> active;
-    call_matcher_list<Sig> saturated;
+    call_matcher_list<Sig> active{};
+    call_matcher_list<Sig> saturated{};
   };
 
   template <typename Sig, typename ... P>

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -4325,7 +4325,7 @@ template <typename T>
     return {nullptr, 0ul, nullptr};                                            \
   }                                                                            \
                                                                                \
-  mutable TROMPELOEIL_LINE_ID(expectation_list_t) TROMPELOEIL_LINE_ID(expectations)
+  mutable TROMPELOEIL_LINE_ID(expectation_list_t) TROMPELOEIL_LINE_ID(expectations){}
 
 
 #define TROMPELOEIL_LPAREN (

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1,7 +1,7 @@
 /*
  * Trompeloeil C++ mocking framework
  *
- * Copyright Björn Fahller 2014-2018
+ * Copyright Björn Fahller 2014-2019
  * Copyright (C) 2017, 2018 Andrew Paxie
  *
  *  Use, modification and distribution is subject to the
@@ -294,6 +294,8 @@
   /**/
 
 #endif /* !(TROMPELOEIL_CPLUSPLUS == 201103L) */
+
+struct trompeloeil_movable_mock {};
 
 namespace trompeloeil
 {
@@ -3875,7 +3877,7 @@ template <typename T>
     }
   };
 
-  template <typename Sig>
+  template <typename Mock, typename Sig>
   struct expectations
   {
     expectations() = default;
@@ -3888,14 +3890,33 @@ template <typename T>
     call_matcher_list<Sig> saturated;
   };
 
+  template <typename Sig>
+  struct expectations<::trompeloeil_movable_mock, Sig>
+  {
+    expectations() = default;
+    expectations(expectations&&)
+    {
+      static_assert(std::is_same<Sig,void>::value,
+        "By default, mock objects are not movable. "
+        "To make a mock object movable, see: "
+        "https://github.com/rollbear/trompeloeil/blob/master/docs/reference.md#movable_mock");
+    }
+    ~expectations() {
+      active.decommission();
+      saturated.decommission();
+    }
+    call_matcher_list<Sig> active;
+    call_matcher_list<Sig> saturated;
+  };
+
   template <typename Sig, typename ... P>
   return_of_t<Sig> mock_func(std::false_type, P&& ...);
 
 
-  template <typename Sig, typename ... P>
+  template <typename M, typename Sig, typename ... P>
   return_of_t<Sig>
   mock_func(std::true_type,
-            expectations<Sig>& e,
+            expectations<M, Sig>& e,
             char const *func_name,
             char const *sig_name,
             P&& ... p)
@@ -4212,7 +4233,9 @@ template <typename T>
   static_assert(TROMPELOEIL_LINE_ID(cardinality_match)::value,                 \
                 "Function signature does not have " #num " parameters");       \
   using TROMPELOEIL_LINE_ID(matcher_list_t) = ::trompeloeil::call_matcher_list<sig>;\
-  using TROMPELOEIL_LINE_ID(expectation_list_t) = ::trompeloeil::expectations<sig>; \
+  using TROMPELOEIL_LINE_ID(expectation_list_t) =                              \
+    ::trompeloeil::expectations<trompeloeil_movable_mock, sig>;                \
+                                                                               \
   struct TROMPELOEIL_LINE_ID(tag_type_trompeloeil)                             \
   {                                                                            \
     const char* trompeloeil_expectation_file;                                  \
@@ -4279,11 +4302,12 @@ template <typename T>
                                                                                \
     ::trompeloeil::ignore(s_ptr, e_ptr);                                       \
                                                                                \
-    return ::trompeloeil::mock_func<sig>(TROMPELOEIL_LINE_ID(cardinality_match){},  \
-                                         TROMPELOEIL_LINE_ID(expectations),    \
-                                         #name,                                \
-                                         #sig                                  \
-                                         TROMPELOEIL_PARAMS(num));             \
+    return ::trompeloeil::mock_func<trompeloeil_movable_mock, sig>(            \
+                                    TROMPELOEIL_LINE_ID(cardinality_match){},  \
+                                    TROMPELOEIL_LINE_ID(expectations),         \
+                                    #name,                                     \
+                                    #sig                                       \
+                                    TROMPELOEIL_PARAMS(num));                  \
   }                                                                            \
                                                                                \
   auto                                                                         \

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -3878,6 +3878,8 @@ template <typename T>
   template <typename Sig>
   struct expectations
   {
+    expectations() = default;
+    expectations(expectations&&) = default;
     ~expectations() {
       active.decommission();
       saturated.decommission();

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -295,7 +295,7 @@
 
 #endif /* !(TROMPELOEIL_CPLUSPLUS == 201103L) */
 
-struct trompeloeil_movable_mock {};
+static constexpr bool trompeloeil_movable_mock = false;
 
 namespace trompeloeil
 {
@@ -3877,7 +3877,7 @@ template <typename T>
     }
   };
 
-  template <typename Mock, typename Sig>
+  template <bool movable, typename Sig>
   struct expectations
   {
     expectations() = default;
@@ -3891,7 +3891,7 @@ template <typename T>
   };
 
   template <typename Sig>
-  struct expectations<::trompeloeil_movable_mock, Sig>
+  struct expectations<false, Sig>
   {
     expectations() = default;
     expectations(expectations&&)
@@ -3913,10 +3913,10 @@ template <typename T>
   return_of_t<Sig> mock_func(std::false_type, P&& ...);
 
 
-  template <typename M, typename Sig, typename ... P>
+  template <bool movable, typename Sig, typename ... P>
   return_of_t<Sig>
   mock_func(std::true_type,
-            expectations<M, Sig>& e,
+            expectations<movable, Sig>& e,
             char const *func_name,
             char const *sig_name,
             P&& ... p)

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -295,6 +295,7 @@ public:
 class movable_mock
 {
 public:
+  movable_mock() = default;
   using trompeloeil_movable_mock = void;
   MAKE_MOCK1(func, void(int));
 };

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -296,7 +296,7 @@ class movable_mock
 {
 public:
   movable_mock() = default;
-  using trompeloeil_movable_mock = void;
+  static constexpr bool trompeloeil_movable_mock = true;
   MAKE_MOCK1(func, void(int));
 };
 

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -298,6 +298,7 @@ public:
   using trompeloeil_movable_mock = void;
   MAKE_MOCK1(func, void(int));
 };
+
 int intfunc(int i);
 
 extern int global_n;

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -1,7 +1,7 @@
 /*
  * Trompeloeil C++ mocking framework
  *
- * Copyright Björn Fahller 2014-2018
+ * Copyright Björn Fahller 2014-2019
  * Copyright (C) 2017, 2018 Andrew Paxie
  *
  *  Use, modification and distribution is subject to the
@@ -292,6 +292,12 @@ public:
   using C::p_;
 };
 
+class movable_mock
+{
+public:
+  using trompeloeil_movable_mock = void;
+  MAKE_MOCK1(func, void(int));
+};
 int intfunc(int i);
 
 extern int global_n;

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -263,6 +263,7 @@ class C
 public:
   C() {}
   C(int) {}
+  C(C&&) = default;
   virtual ~C() = default;
   virtual int count() = 0;
   virtual void func(int, std::string& s) = 0;

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -5275,9 +5275,9 @@ TEST_CASE_METHOD(
 {
   bool called = false;
   auto set_expectation = [&called](auto obj) {
-    auto e = NAMED_REQUIRE_CALL_V(obj, foo("bar"),
+    auto exp = NAMED_REQUIRE_CALL_V(obj, foo("bar"),
                                   .LR_SIDE_EFFECT(called = true));
-    return std::make_pair(std::move(obj), std::move(e));
+    return std::make_pair(std::move(obj), std::move(exp));
   };
 
   auto e = set_expectation(mock_c{});

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -5267,3 +5267,22 @@ TEST_CASE_METHOD(
   m.f2(0,1);
 }
 
+TEST_CASE_METHOD(
+  Fixture,
+  "C++11: A named expectation follows a moved mock object",
+  "[C++11][C++14]"
+)
+{
+  bool called = false;
+  auto set_expectation = [&called](auto obj) {
+    auto e = NAMED_REQUIRE_CALL_V(obj, foo("bar"),
+                                  .LR_SIDE_EFFECT(called = true));
+    return std::make_pair(std::move(obj), std::move(e));
+  };
+
+  auto e = set_expectation(mock_c{});
+  e.first.foo("bar");
+  REQUIRE(reports.empty());
+  REQUIRE(called);
+}
+

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -5274,7 +5274,7 @@ TEST_CASE_METHOD(
 )
 {
   bool called = false;
-  auto set_expectation = [&called](auto obj) {
+  auto set_expectation = [&called](mock_c obj) {
     auto exp = NAMED_REQUIRE_CALL_V(obj, foo("bar"),
                                   .LR_SIDE_EFFECT(called = true));
     return std::make_pair(std::move(obj), std::move(exp));

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -1,7 +1,7 @@
 /*
  * Trompeloeil C++ mocking framework
  *
- * Copyright Björn Fahller 2014-2018
+ * Copyright Björn Fahller 2014-2019
  * Copyright (C) 2017 Andrew Paxie
  *
  *  Use, modification and distribution is subject to the
@@ -5274,14 +5274,14 @@ TEST_CASE_METHOD(
 )
 {
   bool called = false;
-  auto set_expectation = [&called](mock_c obj) {
-    auto exp = NAMED_REQUIRE_CALL_V(obj, foo("bar"),
+  auto set_expectation = [&called](movable_mock obj) {
+    auto exp = NAMED_REQUIRE_CALL_V(obj, func(3),
                                   .LR_SIDE_EFFECT(called = true));
     return std::make_pair(std::move(obj), std::move(exp));
   };
 
-  auto e = set_expectation(mock_c{});
-  e.first.foo("bar");
+  auto e = set_expectation(movable_mock{});
+  e.first.func(3);
   REQUIRE(reports.empty());
   REQUIRE(called);
 }

--- a/test/compiling_tests_14.cpp
+++ b/test/compiling_tests_14.cpp
@@ -3663,6 +3663,7 @@ TEST_CASE_METHOD(
   }
 }
 
+
 // tests on scoping (lifetime) of expectations
 
 TEST_CASE_METHOD(


### PR DESCRIPTION
I *really* want a 2nd pair of eyes on this one. By default mock objects are not movable, because allowing moves when there are live expectations can be really scary.

Allowing an explicit opt-in, with documented (scary) behaviour may be the way to go.

1. Does this actually really work safely?
2. Is the documentation effort on the right balance of correct, easy to understand, and writing on the nose?
3. Should this actually be done?