### PR TITLE
update doc - catch2 integration with runtime adapter

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -194,9 +194,9 @@ Before running any tests, make sure to call:
 ```Cpp
   trompeloeil::set_reporter([](
     trompeloeil::severity s,
-    const char* file,
+    char const* file,
     unsigned long line,
-    const char* msg)
+    std::string const& msg)
   {
     std::ostringstream os;
     if (line) os << file << ':' << line << '\n';


### PR DESCRIPTION
I noticed that the section "Integrating with unit test frame works" was out of date for the section "catch + runtime adapter". It is the first time I try to use trompeloeil, and I was getting the following compilation error when following the current version of the documentation:

```
/home/luis/programming/trompeloeilExample/tests/testMain.cpp:27:6: error: could not convert ‘<lambda closure object>main(int, char**)::<lambda(trompeloeil::severity, const char*, long unsigned int, const char*)>{}’ from ‘main(int, char**)::<lambda(trompeloeil::severity, const char*, long unsigned int, const char*)>’ to ‘trompeloeil::reporter_func {aka std::function<void(trompeloeil::severity, const char*, long unsigned int, const std::__cxx11::basic_string<char>&)>}’
     });
```
By changing the lambda signature to what it is specified in `trompeloeil.hpp:735` I could fix the issue and have my first mocking tests running :wink: 

Note that I changed the 'const-side' just to match with the alias defined in the trompeloeil header.