### PR TITLE
Added hook so that successful tests can be reported correctly

### DIFF
--- a/include/catch2/trompeloeil.hpp
+++ b/include/catch2/trompeloeil.hpp
@@ -44,6 +44,13 @@ namespace trompeloeil
       CHECK(failure.empty());
     }
   }
+
+  template <>
+  inline void reporter<specialized>::sendOk(
+    const char* trompeloeil_mock_calls_done_correctly)
+  {      
+      REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
+  }
 }
 
 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -865,6 +865,14 @@ namespace trompeloeil
   }
 
   template <typename T>
+  void
+  send_ok_report(
+    std::string const &msg)
+  {
+    reporter<T>::sendOk(msg.c_str());
+  }
+
+  template <typename T>
   struct reporter
   {
     static
@@ -874,6 +882,12 @@ namespace trompeloeil
       char const *file,
       unsigned long line,
       char const *msg);
+
+    static
+    void
+    sendOk(
+      char const *msg);
+
   };
 
   template <typename T>
@@ -887,6 +901,13 @@ namespace trompeloeil
       reporter_obj()(s, file, line, msg);
     }
 
+  template <typename T>
+  void reporter<T>::
+    sendOk(char const *msg)
+    {
+        (void)msg;
+    }
+    
   template <typename ... T>
   inline
   constexpr
@@ -3019,6 +3040,19 @@ template <typename T>
   }
 
   template <typename Sig>
+  void
+  report_match(
+    call_matcher_list <Sig> &matcher_list)
+  {
+    std::ostringstream os;
+    for (auto& m : matcher_list)
+    {
+        os << m.name;
+    }
+    send_ok_report<specialized>(os.str());
+  }
+    
+  template <typename Sig>
   class return_handler
   {
   public:
@@ -3943,6 +3977,9 @@ template <typename T>
                       e.saturated,
                       func_name + std::string(" with signature ") + sig_name,
                       param_value);
+    }
+    else{
+        report_match(e.active);
     }
     trace_agent ta{i->loc, i->name, tracer_obj()};
     try


### PR DESCRIPTION
Catch2 has a framework to report number of assertions and list
which testcases it has ran. This does not work with REQUIRE_CALL
in trompeloeil.

Given a test in catch2 like this

SCENARIO("Foo test")
{
    WHEN("foo called"){
        THEN("call barfunc"){
            REQUIRE_CALL(bar, barfunc(5, ANY(int))).RETURN(4);
            foo.foo(5, 6);
        }
    }
}

will be reported as this:
  ===============================================================================
  test cases: 1 | 1 passed
  assertions: - none -

If you run the test with the -s option to include  successful tests in ouput
you get the same output as above

With this fix REQUIRE_CALL is counted as asserts and are included in the
successful output like this:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  footest is a Catch v2.8.0 host application.
  Run with -? for options

  -------------------------------------------------------------------------------
  Scenario: Foo test
         When: foo called
         Then: call barfunc
  -------------------------------------------------------------------------------
  /scratch/onetechmain/qt/test/HwModules/gpio/FooTest.cpp:50
  ...............................................................................

  /scratch/onetechmain/qt/test/TestHelpers/trompeloeil/include/catch2/trompeloeil.hpp:52: PASSED:
    REQUIRE( trompeloeil_mock_calls_done_correctly != 0 )
  with expansion:
    "bar.barfunc(5, ANY(int))" != 0

  ===============================================================================
  All tests passed (1 assertion in 1 test case)