### PR TITLE
Update CookBook.md

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -1658,10 +1658,10 @@ class char_buff : public std::vector<char>
 
 namespace trompeloeil {
   template <>
-  void print(std::ostream& os, const char_buff& b)
+  inline void print(std::ostream& os, const char_buff& b)
   {
     os << b.size() << "#{ ";
-    for (auto v : b) { os << int(v) << " ";
+    for (auto v : b) { os << int(v) << " "; }
     os << "}";
   }
 }


### PR DESCRIPTION
Minor fixes so code has higher chances to compile if copypasted.
Added `inline` since this function has to be declared in the header but it's also defined here which violates ODR.