### PR TITLE
Added hook so that successful tests can be reported correctly

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -175,6 +175,28 @@ location. An example is an unexpected call to a
 are no expectations. In these cases `file` will be `""` string and
 `line` == 0.
 
+### Status OK reporting
+It is possible to make an adaption to the reporter that will be called if
+an expectation is met. This can be useful for correct counting and reporting
+from the testing framework.
+
+Provide an inline specialization of the
+`trompeloeil::reporter<trompeloeil::specialized>::sendOk()` function.
+The function should call a matcher in the testing framework that always
+yields true.
+
+Below, as an example, is the adapter for the Catch2 unit testing frame
+work, in the file <catch2/trompeloeil.hpp>
+
+```Cpp
+  template <>
+  inline void reporter<specialized>::sendOk(
+    const char* trompeloeil_mock_calls_done_correctly)
+  {      
+      REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
+  }
+```
+
 ### <A name="adapt_catch"/>Use *Trompeloeil* with [Catch2](https://github.com/catchorg/Catch2)
 
 The easiest way to use *Trompeloeil* with *Catch2* is to

--- a/include/catch2/trompeloeil.hpp
+++ b/include/catch2/trompeloeil.hpp
@@ -2,6 +2,7 @@
  * Trompeloeil C++ mocking framework
  *
  * Copyright Björn Fahller 2014-2019
+ * Copyright Tore Martin Hagen 2019
  *
  *  Use, modification and distribution is subject to the
  *  Boost Software License, Version 1.0. (See accompanying
@@ -43,6 +44,13 @@ namespace trompeloeil
       CAPTURE(failure);
       CHECK(failure.empty());
     }
+  }
+
+  template <>
+  inline void reporter<specialized>::sendOk(
+    const char* trompeloeil_mock_calls_done_correctly)
+  {      
+      REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
   }
 }
 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -3,6 +3,7 @@
  *
  * Copyright Björn Fahller 2014-2019
  * Copyright (C) 2017, 2018 Andrew Paxie
+ * Copyright Tore Martin Hagen 2019
  *
  *  Use, modification and distribution is subject to the
  *  Boost Software License, Version 1.0. (See accompanying
@@ -872,6 +873,14 @@ namespace trompeloeil
   }
 
   template <typename T>
+  void
+  send_ok_report(
+    std::string const &msg)
+  {
+    reporter<T>::sendOk(msg.c_str());
+  }
+
+  template <typename T>
   struct reporter
   {
     static
@@ -881,6 +890,12 @@ namespace trompeloeil
       char const *file,
       unsigned long line,
       char const *msg);
+
+    static
+    void
+    sendOk(
+      char const *msg);
+
   };
 
   template <typename T>
@@ -894,6 +909,12 @@ namespace trompeloeil
       reporter_obj()(s, file, line, msg);
     }
 
+  template <typename T>
+  void reporter<T>::
+    sendOk(char const* /*msg*/)
+    {
+    }
+    
   template <typename ... T>
   inline
   constexpr
@@ -3003,6 +3024,17 @@ template <typename T>
   }
 
   template <typename Sig>
+  void
+  report_match(
+    call_matcher_list <Sig> &matcher_list)
+  {
+    if(! matcher_list.empty())
+    {
+        send_ok_report<specialized>((matcher_list.begin())->name);
+    }
+  }
+   
+  template <typename Sig>
   class return_handler
   {
   public:
@@ -3928,6 +3960,9 @@ template <typename T>
                       e.saturated,
                       func_name + std::string(" with signature ") + sig_name,
                       param_value);
+    }
+    else{
+        report_match(e.active);
     }
     trace_agent ta{i->loc, i->name, tracer_obj()};
     try

--- a/test/compiling_tests.cpp
+++ b/test/compiling_tests.cpp
@@ -30,6 +30,7 @@
 #include "compiling_tests.hpp"
 
 std::vector<report> reports;
+std::vector<std::string> okReports;
 
 int
 intfunc(int i)

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -137,6 +137,7 @@ struct report
 };
 
 extern std::vector<report> reports;
+extern std::vector<std::string> okReports;
 
 namespace trompeloeil
 {
@@ -154,6 +155,11 @@ namespace trompeloeil
         throw reported{};
       }
     }
+      
+    static void sendOk(char const* msg)
+    {
+        okReports.push_back(msg);
+    }
   };
 }
 
@@ -161,6 +167,7 @@ struct Fixture
 {
   Fixture() {
     reports.clear();
+    okReports.clear();
   }
 };
 

--- a/test/compiling_tests_14.cpp
+++ b/test/compiling_tests_14.cpp
@@ -2,6 +2,7 @@
  * Trompeloeil C++ mocking framework
  *
  * Copyright Björn Fahller 2014-2018
+ * Copyright Tore Martin Hagen 2019
  *
  *  Use, modification and distribution is subject to the
  *  Boost Software License, Version 1.0. (See accompanying
@@ -4943,6 +4944,56 @@ TEST_CASE_METHOD(
   m.f0();
   m.f1(0);
   m.f2(0,1);
+}
+
+TEST_CASE_METHOD(
+  Fixture,
+  "C++14: REQUIRE_CALL genereate OK-report when satisfied",
+  "[C++14][matching]")
+{
+  {
+    mock_c obj;
+    REQUIRE_CALL(obj, foo("bar"));
+    obj.foo("bar");
+  }
+  REQUIRE(okReports.size() == 1U);
+}
+
+TEST_CASE_METHOD(
+  Fixture,
+  "C++14: REQUIRE_CALL doesn't genereate OK-report when not satisfied",
+  "[C++14][matching]")
+{
+  {
+    mock_c obj;
+    REQUIRE_CALL(obj, foo("bar"));
+  }
+  REQUIRE(okReports.empty());
+}
+
+TEST_CASE_METHOD(
+  Fixture,
+  "C++14: ALLOW_CALL genereate OK-report when satisfied",
+  "[C++14][matching]")
+{
+  {
+    mock_c obj;
+    ALLOW_CALL(obj, foo("bar"));
+    obj.foo("bar");
+  }
+  REQUIRE(okReports.size() == 1U);
+}
+
+TEST_CASE_METHOD(
+  Fixture,
+  "C++14: ALLOW_CALL doesn't genereate OK-report when not satisfied",
+  "[C++14][matching]")
+{
+  {
+    mock_c obj;
+    REQUIRE_CALL(obj, foo("bar"));
+  }
+  REQUIRE(okReports.empty());
 }
 
 #endif /* TROMPELOEIL_CPLUSPLUS > 201103L */


### PR DESCRIPTION
Catch2 has a framework to report number of assertions and list
which testcases it has ran. This does not work with REQUIRE_CALL
in trompeloeil.

Given a test in catch2 like this

SCENARIO("Foo test")
{
    WHEN("foo called"){
        THEN("call barfunc"){
            REQUIRE_CALL(bar, barfunc(5, ANY(int))).RETURN(4);
            foo.foo(5, 6);
        }
    }
}

will be reported as this:
  ===============================================================================
  test cases: 1 | 1 passed
  assertions: - none -

If you run the test with the -s option to include  successful tests in ouput
you get the same output as above

With this fix REQUIRE_CALL is counted as asserts and are included in the
successful output like this:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  footest is a Catch v2.8.0 host application.
  Run with -? for options

  -------------------------------------------------------------------------------
  Scenario: Foo test
         When: foo called
         Then: call barfunc
  -------------------------------------------------------------------------------
  /scratch/onetechmain/qt/test/HwModules/gpio/FooTest.cpp:50
  ...............................................................................

  /scratch/onetechmain/qt/test/TestHelpers/trompeloeil/include/catch2/trompeloeil.hpp:52: PASSED:
    REQUIRE( trompeloeil_mock_calls_done_correctly != 0 )
  with expansion:
    "bar.barfunc(5, ANY(int))" != 0

  ===============================================================================
  All tests passed (1 assertion in 1 test case)