### PR TITLE
Enable "Status OK reporting" in doctest

### DIFF
--- a/include/doctest/trompeloeil.hpp
+++ b/include/doctest/trompeloeil.hpp
@@ -40,6 +40,17 @@ namespace trompeloeil
       DOCTEST_ADD_FAIL_CHECK_AT(f, line, msg);
     }
   }
+
+  template <>
+  inline void reporter<specialized>::sendOk(
+    const char* trompeloeil_mock_calls_done_correctly)
+  {
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    DOCTEST_REQUIRE_UNARY(trompeloeil_mock_calls_done_correctly);
+#else
+    DOCTEST_REQUIRE_NE(doctest::String(trompeloeil_mock_calls_done_correctly), "");
+#endif
+  }
 }
 
 


### PR DESCRIPTION
With DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING this prints

```
trompeloeil/include/doctest/trompeloeil.hpp:49: SUCCESS: REQUIRE_UNARY( trompeloeil_mock_calls_done_correctly ) is correct!
  values: REQUIRE_UNARY( "foo.func()" )
```

and without

```
trompeloeil/include/doctest/trompeloeil.hpp:51: SUCCESS: REQUIRE_NE( doctest::String(trompeloeil_mock_calls_done_correctly), "" ) is correct!
  values: REQUIRE_NE( foo.func(),  )
```

This is the best I could think of, but @onqtam may have a better idea.