### PR TITLE
Fix remaining issues with issue 173

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+	* Fix TROMPELOEIL_CONCAT macro issue to restore compiling with MSVC
+	  when traditional preprocessor is enabled.
+
+	* Fix issue 173 for GCC 4.x by performing testing to confirm
+	  correctness of existing code.
+
 v36 2019-04-01
 
 	* Status reporting of passed expectation calls as sucessful assertions in

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -150,8 +150,17 @@
   TROMPELOEIL_IDENTITY(TROMPELOEIL_ARG16(__VA_ARGS__,                          \
                                          15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0))
 
+#if defined(_MSC_VER)
+
+#define TROMPELOEIL_CONCAT_(x, y, ...) x ## y __VA_ARGS__
+#define TROMPELOEIL_CONCAT(x, ...) TROMPELOEIL_CONCAT_(x, __VA_ARGS__)
+
+#else /* defined(_MSC_VER) */
+
 #define TROMPELOEIL_CONCAT_(x, ...) x ## __VA_ARGS__
 #define TROMPELOEIL_CONCAT(x, ...) TROMPELOEIL_CONCAT_(x, __VA_ARGS__)
+
+#endif /* !defined(_MSC_VER) */
 
 #define TROMPELOEIL_REMOVE_PAREN(...) TROMPELOEIL_CONCAT(TROMPELOEIL_CLEAR_,   \
   TROMPELOEIL_REMOVE_PAREN_INTERNAL __VA_ARGS__)
@@ -1075,7 +1084,7 @@ template <typename T>
   };
 
   struct indirect_null {
-#if defined(__GNUC__) && !defined(__clang__)
+#if TROMPELOEIL_GCC
     template <typename T, typename C, typename ... As>
     using memfunptr = T (C::*)(As...);
 
@@ -1085,7 +1094,7 @@ template <typename T>
     operator T C::*() const;
     template <typename T, typename C, typename ... As>
     operator memfunptr<T,C,As...>() const;
-#endif
+#endif /* TROMPELOEIL_GCC */
     operator std::nullptr_t() const;
   };
 
@@ -1097,13 +1106,14 @@ template <typename T>
   template <typename T, typename U>
   using is_equal_comparable = is_detected<equality_comparison, T, U>;
 
-#if (defined(__GNUC__) && __GNUC__ <= 4 && !defined(__clang__)) || (defined(_MSC_VER) && _MSC_VER < 1910)
-template <typename T>
-using is_null_comparable = is_equal_comparable<T, std::nullptr_t>;
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+  template <typename T>
+  using is_null_comparable = is_equal_comparable<T, std::nullptr_t>;
 #else
   template <typename T>
   using is_null_comparable = is_equal_comparable<T, indirect_null>;
 #endif
+
   template <typename T>
   inline
   constexpr
@@ -4351,7 +4361,7 @@ using is_null_comparable = is_equal_comparable<T, std::nullptr_t>;
   }                                                                            \
                                                                                \
   ::trompeloeil::return_of_t<TROMPELOEIL_REMOVE_PAREN(sig)>                    \
-  name(TROMPELOEIL_PARAM_LIST(num, TROMPELOEIL_REMOVE_PAREN(sig)))             \
+  name(TROMPELOEIL_PARAM_LIST(num, sig))                                       \
   constness                                                                    \
   spec                                                                         \
   {                                                                            \

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -3385,6 +3385,7 @@ TEST_CASE_METHOD(
 
 Tried obj\.uptrrr\(\*trompeloeil::eq\(3\)\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
   Expected \*_1 == 3):";
+    INFO("msg=" << reports.front().msg);
     REQUIRE(is_match(reports.front().msg, re));
   }
 }
@@ -3958,7 +3959,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
-  "C++11: A null-comparable object is printed as 'nullptr' if eqeual",
+  "C++11: A null-comparable object is printed as 'nullptr' if equal",
   "[C++11][C++14][streaming]")
 {
   std::ostringstream os;
@@ -3968,7 +3969,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
-  "C++11: A null-comparable object is printed as using its ostream insertion if ueqeual",
+  "C++11: A null-comparable object is printed as using its ostream insertion if unequal",
   "[C++11][C++14][streaming]")
 {
   std::ostringstream os;
@@ -3986,7 +3987,10 @@ TEST_CASE_METHOD(
   REQUIRE(os.str() == "pseudo_null_comparable");
 }
 
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5) || (defined(_MSC_VER) && _MSC_VER >= 1910)
+#if !(defined(_MSC_VER) && _MSC_VER < 1910)
+// Disable this test case for Microsoft Visual Studio 2015
+// until a working implementation of is_null_comparable is found
+// for this compiler.
 TEST_CASE_METHOD(
   Fixture,
   "C++11: An object that is constructible from null, but not comparable with null, is printed using its ostream insertion",
@@ -3996,7 +4000,8 @@ TEST_CASE_METHOD(
   trompeloeil::print(os, null_constructible{nullptr});
   REQUIRE(os.str() == "null_constructible");
 }
-#endif
+#endif /* !(defined(_MSC_VER) && _MSC_VER < 1910) */
+
 // tests on scoping (lifetime) of expectations
 
 TEST_CASE_METHOD(


### PR DESCRIPTION
#### trompeloeil.hpp

Modified `TROMPELOEIL_CONCAT` to work with old MSVC preprocessor.
This fixed a compile error in `TROMPELOEIL_REQUIRE_DESTRUCTION`
on MSVC compilers.  Not sure why Appveyor builds succeed.

Simplified expression for preprocessor guard around code
specific to GCC.

Narrowed scope of fallback implementation for `is_null_comparable`
to just MSVC 14.0 or earlier.

Removed an invocation of `TROMPELEOIL_REMOVE_PARENS` in call of
`TROMPELOEIL_PARAM_LIST` since the latter calls the former
internally.  Might be without effect but makes the code consistent
with other uses of the `TROMPELOEIL_PARAM_LIST` macro.

#### Unit tests

Tightened constraints on `null_constructible` to say explicitly
that comparison with `std::nullptr_t` is not supported.
I think this type is now an instance of the concept we wanted to model.
This change allows MSVC 14.0 to compile all test cases.

Enabled `null_constructible` test case as it was working with GCC 4.x
and now also passes with MSVC 14.0.

Modest improvements to test cases:

- More `INFO` on test case failure.
- Minor spelling fixes.