### PR TITLE
Rewrite iterator to avoid C++17 deprecation warnings

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1498,9 +1498,13 @@ template <typename T>
 
   template <typename T, typename Disposer>
   class list<T, Disposer>::iterator
-    : public std::iterator<std::bidirectional_iterator_tag, T>
   {
     friend class list<T, Disposer>;
+    typedef std::bidirectional_iterator_tag iterator_category;
+    typedef T value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef T* pointer;
+    typedef T& reference;
   public:
     iterator()
     noexcept


### PR DESCRIPTION
std::iterator has been deprecated in C++17 so rewrite iterator class
to provide the required typedefs instead.

This silences deprecation warnings from MSVC 2017.