### PR TITLE
Add runtime adapter for 'Status OK' reporting

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -154,11 +154,15 @@ using reporter_func = std::function<void(
   char const *file,
   unsigned long line,
   std::string const &msg)>;
-reporter_func trompeloeil::set_reporter(reporter_func new_reporter)
+using ok_reporter_func = std::function<void(char const *msg)>;
+
+reporter_func trompeloeil::set_reporter(reporter_func new_reporter);
+reporter_func trompeloeil::set_reporter(
+  reporter_func new_reporter, ok_reporter_func new_ok_reporter)
 ```
 
 Call it with the adapter to your test frame work. The return value is the old
-adapter.
+adapter. The overload is provided to allow you to also set an 'OK reporter' at the same time. See the next section for details.
 
 It is important to understand the first parameter
 `trompeloeil::severity`. It is an enum with the values
@@ -182,21 +186,34 @@ a positive expectation is met. This can be useful for correct counting and repor
 from the testing framework. Negative expectations like `FORBID_CALL` and
 `.TIMES(0)` are not counted.
 
-Provide an inline specialization of the
-`trompeloeil::reporter<trompeloeil::specialized>::sendOk()` function.
+Either provide your adapter as an inline specialization of the
+`trompeloeil::reporter<trompeloeil::specialized>::sendOk()` function at compile time or as the second argument to `trompeloeil::set_reporter(new_reporter, new_ok_reporter)` at runtime.
 The function should call a matcher in the testing framework that always
 yields true.
 
-Below, as an example, is the adapter for the Catch2 unit testing frame
-work, in the file <catch2/trompeloeil.hpp>
+Below, as an example, is the compile time adapter for the Catch2 unit testing frame
+work, in the file `<catch2/trompeloeil.hpp>`
 
 ```Cpp
   template <>
   inline void reporter<specialized>::sendOk(
     const char* trompeloeil_mock_calls_done_correctly)
   {      
-      REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
+      REQUIRE(trompeloeil_mock_calls_done_correctly);
   }
+```
+
+If you roll your own `main()`, you may prefer a runtime adapter instead. Please note that the first param given to `set_reporter()` here is a dummy - see the sections below for implementation examples for your unit testing framework of choice.
+
+```Cpp
+trompeloeil::set_reporter(
+  [](auto, auto, auto, auto) {}, // Not relevant here
+  [](const char* trompeloeil_mock_calls_done_correctly)
+    {
+      // Example for Catch2
+      REQUIRE(trompeloeil_mock_calls_done_correctly);
+    }
+);
 ```
 
 Below is a simple example for *Catch2*:

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -760,6 +760,8 @@ namespace trompeloeil
                                            unsigned long line,
                                            std::string const &msg)>;
 
+  using ok_reporter_func = std::function<void(char const *msg)>;
+
   inline
   void
   default_reporter(
@@ -777,10 +779,25 @@ namespace trompeloeil
   }
 
   inline
+  void
+  default_ok_reporter(char const* /*msg*/)
+  {
+    /* OK reporter defaults to doing nothing. */
+  }
+
+  inline
   reporter_func&
   reporter_obj()
   {
     static reporter_func obj = default_reporter;
+    return obj;
+  }
+
+  inline
+  ok_reporter_func&
+  ok_reporter_obj()
+  {
+    static ok_reporter_func obj = default_ok_reporter;
     return obj;
   }
 
@@ -790,6 +807,16 @@ namespace trompeloeil
     reporter_func f)
   {
     return detail::exchange(reporter_obj(), std::move(f));
+  }
+
+  inline
+  reporter_func
+  set_reporter(
+    reporter_func rf,
+    ok_reporter_func orf)
+  {
+    detail::exchange(ok_reporter_obj(), std::move(orf));
+    return set_reporter(rf);
   }
 
   class tracer;
@@ -911,8 +938,9 @@ namespace trompeloeil
 
   template <typename T>
   void reporter<T>::
-    sendOk(char const* /*msg*/)
+    sendOk(char const* msg)
     {
+      ok_reporter_obj()(msg);
     }
     
   template <typename ... T>


### PR DESCRIPTION
Provide a `set_reporter(reporter_function, ok_reporter_function)` overload to allow users to set a 'Status OK' reporter at runtime. Previously this was only possible at compile time by specializing `reporter::sendOk()`.

Fixes #186.

Please let me know whether I can / should add any tests for this.