### PR TITLE
Support embedded, 32 bit plattforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -427,6 +427,7 @@ before_script:
   - mkdir build && cd build
   - CXX=${COMPILER} cmake -DCXX_STANDARD="${CXX_STANDARD}" -DCMAKE_BUILD_TYPE=Debug -DTRAVIS_JOB_ID='${TRAVIS_JOB_ID}' -DSANITIZE=${SANITIZE} ..
   - make VERBOSE=1 self_test
+  - make VERBOSE=1 custom_recursive_mutex
 
 script:
   make run_self_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,30 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
     )
   endif()
 
+  add_executable(
+    custom_recursive_mutex
+    EXCLUDE_FROM_ALL
+    test/custom_recursive_mutex.cpp
+  )
+
+  target_link_libraries(
+    custom_recursive_mutex
+    PUBLIC
+    trompeloeil
+    pthread
+  )
+
+  if (SANITIZE)
+    set_target_properties(
+      custom_recursive_mutex
+      PROPERTIES
+        LINK_FLAGS
+          "${SSAN} -fuse-ld=gold"
+        COMPILE_FLAGS
+          ${SSAN}
+      )
+  endif()
+
   # Shameless hack to get target to work on Windows.
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 

--- a/docs/PlatformsAndLibraries.md
+++ b/docs/PlatformsAndLibraries.md
@@ -13,6 +13,8 @@
   - [Glibc 2.26 no longer supplies `xlocale.h`](#defect_xlocale)
   - [Glibc 2.26 `std::signbit()` broken for GCC compilers < 6](#defect_signbit)
   - [Conclusion](#artful_conclusion)
+- [Support platforms without std::recursive_mutex](#custom_recursive_mutex)  
+
 
 ## <A name="using_libcxx"/> Using libc\+\+ with Trompeloeil
 
@@ -521,3 +523,10 @@ A better strategy may be to build GLIBC, GCC 4.8, GCC 5.x, and `libc++`
 from source and use these to build your software.  Then consider
 contributing your build to the Ubuntu Community; you just might be the
 "support" in "community supported".
+
+## <A name="custom_recursive_mutex"/> Support platforms without std::recursive_mutex
+
+Some platforms, especially MCUs with RTOS, don't have native support for std::recursive_mutex.
+To use your own recursive mutex, define `TROMPELOEIL_RECURSIVE_MUTEX` either before including the Trompeloeil header
+(e.g. `#define TROMPELOEIL_RECURSIVE_MUTEX MyRecursiveMutexClass`) or as preprocessor definition
+(e.g. GCC: `-DTROMPELOEIL_RECURSIVE_MUTEX=MyRecursiveMutexClass`).

--- a/docs/PlatformsAndLibraries.md
+++ b/docs/PlatformsAndLibraries.md
@@ -527,6 +527,29 @@ contributing your build to the Ubuntu Community; you just might be the
 ## <A name="custom_recursive_mutex"/> Support platforms without std::recursive_mutex
 
 Some platforms, especially MCUs with RTOS, don't have native support for std::recursive_mutex.
-To use your own recursive mutex, define `TROMPELOEIL_RECURSIVE_MUTEX` either before including the Trompeloeil header
-(e.g. `#define TROMPELOEIL_RECURSIVE_MUTEX MyRecursiveMutexClass`) or as preprocessor definition
-(e.g. GCC: `-DTROMPELOEIL_RECURSIVE_MUTEX=MyRecursiveMutexClass`).
+To use your own recursive mutex, define `TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX` either before including
+the Trompeloeil header (e.g. `#define TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX`) or as preprocessor
+definition (e.g. GCC: `-DTROMPELOEIL_CUSTOM_RECURSIVE_MUTEX`).
+
+Now define in one translation unit your custom recursive mutex for trompeloeil.
+
+```cpp
+
+namespace trompeloeil {
+
+std::unique_ptr<custom_recursive_mutex> create_custom_recursive_mutex() {
+
+	class custom : public custom_recursive_mutex {
+		void lock() override { mtx.lock(); }
+		void unlock() override { mtx.unlock(); }
+
+	private:
+		mylib::recursive_mutex mtx;
+	};
+
+	return std::make_unique<custom>();
+}
+
+}
+
+```

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -705,8 +705,14 @@ namespace trompeloeil
   using aligned_storage_for =
     typename std::aligned_storage<sizeof(T), alignof(T)>::type;
 
+# ifndef TROMPELOEIL_RECURSIVE_MUTEX
+#   define TROMPELOEIL_RECURSIVE_MUTEX std::recursive_mutex
+# endif
+
+  using recursive_mutex = TROMPELOEIL_RECURSIVE_MUTEX;
+
   template <typename T = void>
-  std::unique_lock<std::recursive_mutex> get_lock()
+  std::unique_lock<recursive_mutex> get_lock()
   {
     // Ugly hack for lifetime of mutex. The statically allocated
     // recursive_mutex is intentionally leaked, to ensure that the
@@ -714,9 +720,9 @@ namespace trompeloeil
     // the destructor of a global object in a translation unit
     // without #include <trompeloeil.hpp>
 
-    static aligned_storage_for<std::recursive_mutex> buffer;
-    static auto mutex = new (&buffer) std::recursive_mutex;
-    return std::unique_lock<std::recursive_mutex>{*mutex};
+    static aligned_storage_for<recursive_mutex> buffer;
+    static auto mutex = new (&buffer) recursive_mutex;
+    return std::unique_lock<recursive_mutex>{*mutex};
   }
 
   template <size_t N, typename T>

--- a/test/custom_recursive_mutex.cpp
+++ b/test/custom_recursive_mutex.cpp
@@ -1,0 +1,28 @@
+#define TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX
+#include <trompeloeil.hpp>
+
+namespace trompeloeil {
+
+std::unique_ptr<custom_recursive_mutex> create_custom_recursive_mutex() {
+
+  class custom : public custom_recursive_mutex {
+    void lock() override { mtx.lock(); }
+    void unlock() override { mtx.unlock(); }
+
+  private:
+    std::recursive_mutex mtx;
+  };
+
+  return std::make_unique<custom>();
+}
+
+} // namespace trompeloeil
+
+class C {
+public:
+  MAKE_MOCK0(func, int(void));
+};
+
+int main() {
+  C c;
+}


### PR DESCRIPTION
Sometimes we run our unit tests on our target device (STM32).
In order to use trompeloeil, two changes are required:

1. Add an option set a custom recursive mutex type.

`std::recursive_mutex` is not available on bare-metal or RTOS. But it can provide a custom one.

2. Use `size_t` instead of `unsigned long long`.

`std::atomic<unsigned long long>` (used to keep track of the call count) is not available on 32-bit CPUs. I suggest to make this dependend on the size of `size_t` which is 4 bytes on 32-bit and 8 bytes on 64-bit.