### PR TITLE
Allow using custom std::atomic and std::unique_lock implementations

### DIFF
--- a/docs/PlatformsAndLibraries.md
+++ b/docs/PlatformsAndLibraries.md
@@ -13,7 +13,10 @@
   - [Glibc 2.26 no longer supplies `xlocale.h`](#defect_xlocale)
   - [Glibc 2.26 `std::signbit()` broken for GCC compilers < 6](#defect_signbit)
   - [Conclusion](#artful_conclusion)
-- [Support platforms without std::recursive_mutex](#custom_recursive_mutex)  
+- [<A name="incomplete_stdlib"/> Supporting incomplete standard libraries](#a-nameincomplete_stdlib-supporting-incomplete-standard-libraries)
+  - [<A name="custom_recursive_mutex"/> Replacing std::recursive_mutex](#a-namecustom_recursive_mutex-replacing-stdrecursive_mutex)
+  - [<A name="custom_std_atomic"/> Replacing std::atomic\<T\>](#a-namecustom_std_atomic-replacing-stdatomict)
+  - [<A name="custom_std_unique_lock"/> Replacing std::unique_lock\<T\>](#a-namecustom_std_unique_lock-replacing-stdunique_lockt)
 
 
 ## <A name="using_libcxx"/> Using libc\+\+ with Trompeloeil
@@ -524,9 +527,12 @@ from source and use these to build your software.  Then consider
 contributing your build to the Ubuntu Community; you just might be the
 "support" in "community supported".
 
-## <A name="custom_recursive_mutex"/> Support platforms without std::recursive_mutex
+## <A name="incomplete_stdlib"/> Supporting incomplete standard libraries
 
-Some platforms, especially MCUs with RTOS, don't have native support for std::recursive_mutex.
+Some platforms, especially MCUs with RTOS, only have partial support for the standard library `<atomic>` and `<mutex>` headers used by trompeloeil. In many cases, it is possible to provide shims or custom implementations of the necessary parts.
+
+### <A name="custom_recursive_mutex"/> Replacing std::recursive_mutex
+
 To use your own recursive mutex, define `TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX` either before including
 the Trompeloeil header (e.g. `#define TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX`) or as preprocessor
 definition (e.g. GCC: `-DTROMPELOEIL_CUSTOM_RECURSIVE_MUTEX`).
@@ -550,6 +556,96 @@ std::unique_ptr<custom_recursive_mutex> create_custom_recursive_mutex() {
 	return std::make_unique<custom>();
 }
 
+}
+
+```
+
+### <A name="custom_std_atomic"/> Replacing std::atomic\<T\>
+
+To use your own implementation of std::atomic\<T\>, define `TROMPELOEIL_CUSTOM_ATOMIC` and make sure there is a header `trompeloeil/custom_atomic.hpp` somewhere in the include search path.
+
+This header should contain a class template `trompeloeil::atomic<T>` that implements (part of) the interface of `std::atomic<T>`:
+
+```cpp
+
+namespace trompeloeil
+{
+template <typename T>
+class atomic
+{
+public:
+  atomic() : m_atomic()
+  {
+  }
+
+  explicit atomic(const T initial) : m_atomic(initial)
+  {
+  }
+
+  T operator=(T desired)
+  {
+    m_atomic.store(desired);
+    return m_atomic.load();
+  }
+
+  operator T() const
+  {
+    return m_atomic.load();
+  }
+
+private:
+  mylib::atomic<T> m_atomic;
+};
+}
+
+```
+
+### <A name="custom_std_unique_lock"/> Replacing std::unique_lock\<T\>
+
+To use your own implementation of std::unique_lock\<T\>, define `TROMPELOEIL_CUSTOM_UNIQUE_LOCK` and make sure there is a header `trompeloeil/custom_unique_lock.hpp` somewhere in the include search path.
+
+This header should contain a class template `trompeloeil::unique_lock<T>` that implements (part of) the interface of `std::unique_lock<T>`:
+
+```cpp
+
+namespace trompeloeil
+{
+template <typename Mutex>
+class unique_lock
+{
+public:
+  unique_lock() noexcept : m_mutex(nullptr)
+  {
+  }
+
+  explicit unique_lock(Mutex& mutex) : m_mutex(&mutex)
+  {
+    m_mutex->lock();
+  }
+
+  unique_lock(const unique_lock&) = delete;
+  unique_lock(unique_lock&& other) noexcept : m_mutex(nullptr)
+  {
+    std::swap(other.m_mutex, m_mutex);
+  }
+
+  unique_lock& operator=(const unique_lock&) = delete;
+  unique_lock& operator=(unique_lock&& other) noexcept
+  {
+    std::swap(other.m_mutex, m_mutex);
+  }
+
+  ~unique_lock()
+  {
+    if (m_mutex)
+    {
+      m_mutex->unlock();
+    }
+  }
+
+private:
+  Mutex* m_mutex;
+};
 }
 
 ```

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -129,11 +129,17 @@
 #include <cstring>
 #include <regex>
 #include <mutex>
-#include <atomic>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>
 
+
+#ifndef TROMPELOEIL_CUSTOM_ATOMIC
+#include <atomic>
+namespace trompeloeil { using std::atomic; }
+#else
+#include <trompeloeil/custom_atomic.hpp>
+#endif
 
 #ifdef TROMPELOEIL_SANITY_CHECKS
 #include <cassert>
@@ -2666,7 +2672,7 @@ template <typename T>
       sequences.reset(seq);
     }
   private:
-    std::atomic<bool>  died{false};
+    atomic<bool>       died{false};
     lifetime_monitor *&object_monitor;
     location           loc;
     char const        *object_name;
@@ -3870,8 +3876,8 @@ template <typename T>
     std::unique_ptr<return_handler<Sig>>   return_handler_obj;
     std::unique_ptr<sequence_handler_base> sequences;
     size_t                                 call_count = 0;
-    std::atomic<size_t>                    min_calls{1};
-    std::atomic<size_t>                    max_calls{1};
+    atomic<size_t>                         min_calls{1};
+    atomic<size_t>                         max_calls{1};
     Value                                  val;
     bool                                   reported = false;
   };

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -141,6 +141,12 @@ namespace trompeloeil { using std::atomic; }
 #include <trompeloeil/custom_atomic.hpp>
 #endif
 
+#ifndef TROMPELOEIL_CUSTOM_UNIQUE_LOCK
+namespace trompeloeil { using std::unique_lock; }
+#else
+#include <trompeloeil/custom_unique_lock.hpp>
+#endif
+
 #ifdef TROMPELOEIL_SANITY_CHECKS
 #include <cassert>
 #define TROMPELOEIL_ASSERT(x) assert(x)
@@ -714,7 +720,7 @@ namespace trompeloeil
 #ifndef TROMPELOEIL_CUSTOM_RECURSIVE_MUTEX
 
   template <typename T = void>
-  std::unique_lock<std::recursive_mutex> get_lock()
+  unique_lock<std::recursive_mutex> get_lock()
   {
     // Ugly hack for lifetime of mutex. The statically allocated
     // recursive_mutex is intentionally leaked, to ensure that the
@@ -724,7 +730,7 @@ namespace trompeloeil
 
     static aligned_storage_for<std::recursive_mutex> buffer;
     static auto mutex = new (&buffer) std::recursive_mutex;
-    return std::unique_lock<std::recursive_mutex>{*mutex};
+    return unique_lock<std::recursive_mutex>{*mutex};
   }
 
 #else
@@ -740,10 +746,11 @@ namespace trompeloeil
   std::unique_ptr<custom_recursive_mutex> create_custom_recursive_mutex();
 
   template <typename T = void>
-  std::unique_lock<custom_recursive_mutex> get_lock() {
+  unique_lock<custom_recursive_mutex> get_lock()
+  {
     static std::unique_ptr<custom_recursive_mutex> mtx =
         create_custom_recursive_mutex();
-    return std::unique_lock<custom_recursive_mutex>{*mtx};
+    return unique_lock<custom_recursive_mutex>{*mtx};
   }
 
 #endif


### PR DESCRIPTION
This is sort of in the same vein as #199. We're using trompe l'oeil on an embedded platform where the standard library doesn't provide `<atomic>` at all, and only provides an incomplete `<mutex>` from which `std::unique_lock` is missing.

These changes allow us to provide implementations of `std::atomic` and `std::unique_lock` based on the primitives provided by the RTOS, much in the same way #199 does for std::recursive_mutex.