### PR TITLE
Fix (?) compilation error on clang 9 and 10

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1128,13 +1128,11 @@ template <typename T>
   };
 
   struct indirect_null {
-#if !TROMPELOEIL_CLANG
     template <
       typename T,
       typename = detail::enable_if_t<!std::is_constructible<T, std::nullptr_t>::value>
     >
     operator T&&() const = delete;
-#endif
 #if TROMPELOEIL_GCC
 
     template <typename T, typename C, typename ... As>


### PR DESCRIPTION
We see compilation errors in our testing code base on clang 9 and 10 when attempting an update from v35 to v38. The errors looked equivalent to the ones reported in #180. Your [final comment](https://github.com/rollbear/trompeloeil/issues/180#issuecomment-583833234) in the mentioned issue caught my attention and I noticed that this "workaround" (?) is specifically *disabled* for clang. When enabling it, our compilation issues on clang went away and everything worked fine.

Note, that we're using Qt in our application, so it is likely that `QChar` is playing similar tricks as described in the above-mentioned issue. Further note, that I didn't really deep-dive in the mechanics of this code, I merely got lucky. ;-)

Compile error:

```
In file included from ../test/integration/i_JournalManager.cpp:2:
In file included from /Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/trompeloeil.hpp:23:
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:1207:12: error: no matching function for call to 'is_null'
    return ::trompeloeil::is_null(t, tag{});
           ^~~~~~~~~~~~~~~~~~~~~~
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:1336:9: note: in instantiation of function template specialization 'trompeloeil::is_null<dvault::sync::UserRole>' requested here
    if (is_null(t))
        ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:2941:20: note: in instantiation of function template specialization 'trompeloeil::print<dvault::sync::UserRole>' requested here
    ::trompeloeil::print(os, t);
                   ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:2952:55: note: in instantiation of function template specialization 'trompeloeil::missed_value<dvault::sync::UserRole>' requested here
    ::trompeloeil::ignore(std::initializer_list<int>{(missed_value(os, I, std::get<I>(t)),0)...});
                                                      ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:2961:5: note: in instantiation of function template specialization 'trompeloeil::stream_params<0, dvault::sync::UserRole &>' requested here
    stream_params(os, detail::make_index_sequence<sizeof...(T)>{}, t);
    ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:3094:5: note: in instantiation of function template specialization 'trompeloeil::stream_params<dvault::sync::UserRole &>' requested here
    stream_params(os, p);
    ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:4060:7: note: in instantiation of function template specialization 'trompeloeil::report_mismatch<dvault::sync::Role (dvault::sync::UserRole)>' requested here
      report_mismatch(e.active,
      ^
../test/mocks/JournalMock.h:169:1732: note: in instantiation of function template specialization 'trompeloeil::mock_func<false, dvault::sync::Role (dvault::sync::UserRole), dvault::sync::UserRole &>' requested here
    private: using trompeloeil_l_cardinality_match_169 = std::integral_constant<bool, 1 == ::trompeloeil::param_list< Role(UserRole)>::size>; static_assert(trompeloeil_l_cardinality_match_169::value, "Function signature does not have " "1" " parameters"); using trompeloeil_l_matcher_list_t_169 = ::trompeloeil::call_matcher_list< Role(UserRole)>; using trompeloeil_l_expectation_list_t_169 = ::trompeloeil::expectations<trompeloeil_movable_mock, Role(UserRole)>; struct trompeloeil_l_tag_type_trompeloeil_169 { const char* trompeloeil_expectation_file; unsigned long trompeloeil_expectation_line; const char *trompeloeil_expectation_string; using trompeloeil_sig_t = typename ::trompeloeil::identity_type< Role(UserRole)>::type; using trompeloeil_call_params_type_t = ::trompeloeil::call_params_type_t< Role(UserRole)>; using trompeloeil_return_of_t = ::trompeloeil::return_of_t< Role(UserRole)>; template <typename ... trompeloeil_param_type> auto role( trompeloeil_param_type&& ... trompeloeil_param) -> ::trompeloeil::modifier_t<trompeloeil_sig_t, trompeloeil_l_tag_type_trompeloeil_169, trompeloeil_param_type...> { using matcher = ::trompeloeil::call_matcher< Role(UserRole), ::trompeloeil::param_t<trompeloeil_param_type...>>; return { new matcher { trompeloeil_expectation_file, trompeloeil_expectation_line, trompeloeil_expectation_string, std::forward<trompeloeil_param_type>(trompeloeil_param)... } }; } }; public: trompeloeil_l_matcher_list_t_169& trompeloeil_matcher_list( trompeloeil_l_tag_type_trompeloeil_169*) const noexcept { return trompeloeil_l_expectations_169.active; } ::trompeloeil::return_of_t< Role(UserRole)> role(::trompeloeil::param_list_t<Role(UserRole), 0> p1) const override { return ::trompeloeil::mock_func<trompeloeil_movable_mock, Role(UserRole)>( trompeloeil_l_cardinality_match_169{}, trompeloeil_l_expectations_169, "role", "Role(UserRole)" , p1); }
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:1186:3: note: candidate function template not viable: no known conversion from 'integral_constant<[...], ::trompeloeil::is_null_comparable<UserRole>::value && !is_matcher<UserRole>::value && !std::is_array<UserRole>::value aka true>' to 'integral_constant<[...], false aka false>' for 2nd argument
  is_null(
  ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:1173:3: note: candidate template ignored: substitution failure [with T = dvault::sync::UserRole]: invalid operands to binary expression ('const dvault::sync::UserRole' and 'nullptr_t')
  is_null(
  ^
/Users/rmeusel/.conan/data/trompeloeil/v38/nexenio/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/catch2/../trompeloeil.hpp:1198:3: note: candidate function template not viable: requires single argument 't', but 2 arguments were provided
  is_null(
  ^

[...]
```