### PR TITLE
Add Alias target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion)
 
 add_library(trompeloeil INTERFACE)
+add_library(trompeloeil::trompeloeil ALIAS trompeloeil)
 
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
Hi,

just a quick PR to add an alias target, which has a couple of advantages. One of them is that it's clear that it's a cmake target:
target_link_libraries(myTarget PUBLIC trompeloeil). Here trompeloeil could the lib be a cmake target or a real lib name.
target_link_libraries(myTarget PUBLIC trompeloeil::trompeloeil) is unique though. It will look more consistent and in cases of errors the message will be more specific. It also avoids conflicts when having the library installed globally for instance.