### PR TITLE
Suppress -Wnonnull in GCC 9 and 10 in is_null()

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1237,14 +1237,28 @@ template <typename T>
   inline
   constexpr
   auto
-  is_null(
-    T const &t,
-    std::true_type)
+  is_null_redirect(
+    T const &t)
   noexcept(noexcept(std::declval<T const&>() == nullptr))
   -> decltype(t == nullptr)
   {
     return t == nullptr;
   }
+
+  template <typename T>
+  inline
+  constexpr
+  auto
+  is_null(
+    T const &t,
+    std::true_type)
+  noexcept(noexcept(is_null_redirect(t)))
+  -> decltype(is_null_redirect(t))
+  {
+    // Redirect evaluation to supress wrong non-null warnings in g++ 9 and 10.
+    return is_null_redirect(t);
+  }
+
   template <typename T, typename V>
   inline
   constexpr


### PR DESCRIPTION
There is an annoying warning in GCC 9 and 10 (fixed in 11).

This code:

```c++
#include <trompeloeil.hpp>

class foo {
	MAKE_MOCK1(call, void(const std::string_view&));
};

int main() {
	foo f;
	REQUIRE_CALL(f, call(""));
}
```

Produces this warning:

```
trompeloeil.hpp: In substitution of 'template<class T, class> constexpr decltype ((t == nullptr)) trompeloeil::is_null(const T&, std::true_type) [with T = std::basic_string_view<char>; <template-parameter-1-2> = <missing>]':
trompeloeil.hpp:1285:34:   required from 'constexpr bool trompeloeil::is_null(const T&) [with T = std::basic_string_view<char>]'
trompeloeil.hpp:1414:16:   required from 'void trompeloeil::print(std::ostream&, const T&) [with T = std::basic_string_view<char>; std::ostream = std::basic_ostream<char>]'
trompeloeil.hpp:3199:25:   required from 'void trompeloeil::missed_value(std::ostream&, int, const T&) [with T = std::basic_string_view<char>; std::ostream = std::basic_ostream<char>]'
trompeloeil.hpp:3210:67:   required from 'void trompeloeil::stream_params(std::ostream&, std::index_sequence<I ...>, const std::tuple<_UTypes ...>&) [with long unsigned int ...I = {0}; T = {const std::basic_string_view<char, std::char_traits<char> >&}; std::ostream = std::basic_ostream<char>; std::index_sequence<I ...> = std::integer_sequence<long unsigned int, 0>]'
trompeloeil.hpp:3219:18:   required from 'void trompeloeil::stream_params(std::ostream&, const std::tuple<_Tps ...>&) [with T = {const std::basic_string_view<char, std::char_traits<char> >&}; std::ostream = std::basic_ostream<char>]'
trompeloeil.hpp:3355:18:   required from 'void trompeloeil::report_mismatch(trompeloeil::call_matcher_list<Sig>&, trompeloeil::call_matcher_list<Sig>&, const string&, trompeloeil::call_params_type_t<Sig>&) [with Sig = void(const std::basic_string_view<char>&); std::string = std::__cxx11::basic_string<char>; trompeloeil::call_params_type_t<Sig> = std::tuple<const std::basic_string_view<char, std::char_traits<char> >&>]'
trompeloeil.hpp:4314:22:   required from 'trompeloeil::return_of_t<Sig> trompeloeil::mock_func(std::true_type, trompeloeil::expectations<movable, Sig>&, const char*, const char*, P&& ...) [with bool movable = false; Sig = void(const std::basic_string_view<char>&); P = {const std::basic_string_view<char, std::char_traits<char> >&}; trompeloeil::return_of_t<Sig> = void; std::true_type = std::integral_constant<bool, true>]'
<source>:4:2:   required from here
trompeloeil.hpp:1236:70: warning: null argument where non-null required (argument 2) [-Wnonnull]
Compiler returned: 0
```

See online here: https://gcc.godbolt.org/z/Wqbahq

This change suppresses this warning, by redirect the evaluation of `std::declval<T const&>() == nullptr` to a second function.
See online here: https://gcc.godbolt.org/z/4Gnhb4
