### PR TITLE
Fix documentation for `set_reporter` API in catch

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -238,7 +238,7 @@ If you instead prefer a runtime adapter, make sure to call
 trompeloeil::set_reporter([](trompeloeil::severity,
                              const char* file,
                              unsigned long line,
-                             const char* msg)
+                             const std::string& msg)
   {
     std::ostringstream os;
     os << file << ':' << line;


### PR DESCRIPTION
seems I had made this change several years ago and then sent the PR...to my own master branch instead of yours!