### PR TITLE
Upload coverage on mainline builds only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,7 @@ jobs:
           cmake --build build --target run_coverage || true
 
       - name: Upload coverage
-        if: (startsWith(matrix.config.os, 'ubuntu'))
+        if: startsWith(matrix.config.os, 'ubuntu') && github.repository == 'rollbear/trompeloeil'
         uses: codecov/codecov-action@v1
         with:
           directory: build/coverage


### PR DESCRIPTION
Upload coverage data on builds of this repository only. Trying on a fork will very likely fail all builds.