### PR TITLE
trompeloeil::printer<T> is the new customization point for printing (for #233)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+	* Introduced type trompeloeil::printer<T> as a customization point or
+	  formatting data to strings in reports. This has the advantage of
+	  allowing partial specializations. The old technique of specializing
+	  the function template trompeloeil::print(ostream&, const T&) still
+	  works.
+
 v40 2021-03-14
 
 	* Silenced -Wnonnull warning from GCC 9 and newer. Thank you Tony Neubert.

--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -1834,9 +1834,8 @@ the values are printed using their
 if available, or hexadecimal dumps otherwise. If this is not what you want, you
 can provide your own output formatting used solely for testing.
 
-The simple way to do this is to specialize a function template
-[`print(std::ostream&, const T&)`](reference.md/#print) in namespace
-`trompeloeil` for your type `T`.
+The simple way to do this is to specialize a template [`printer<T>`](reference.md/#printer),
+in namespace `trompeloeil`, and its static member function `print`, for your type `T`.
 
 Example:
 
@@ -1848,17 +1847,47 @@ class char_buff : public std::vector<char>
 
 namespace trompeloeil {
   template <>
-  inline void print(std::ostream& os, const char_buff& b)
+  struct printer<char_buff>
   {
-    os << b.size() << "#{ ";
-    for (auto v : b) { os << int(v) << " "; }
-    os << "}";
-  }
+    static void print(std::ostream& os, const char_buff& b)
+    {
+      os << b.size() << "#{ ";
+      for (auto v : b) { os << int(v) << " "; }
+      os << "}";
+    }
+};
 }
 ```
 
 Any reports involving the `char_buff` above will be printed using the
 `trompeloeil::print<char_buff>(...)` function, showing the size and integer values.
+
+Note that partial specializations also work. Example:
+
+```Cpp
+template <typename T>
+class buff : public std::vector<T>
+{
+  ...
+};
+
+namespace trompeloeil {
+  template <typename T>
+  struct printer<buff<T>>
+  {
+    static void print(std::ostream& os, const buff<T>& b)
+    {
+      os << b.size() << "#{ ";
+      for (auto v : b) { os << v << " "; }
+      os << "}";
+    }
+};
+}
+```
+
+**NOTE!** Older documentation refers to specializing a function
+[`trompeloeil::print(sd::ostream&, T const&)`](reference.md/#print). This still works, but has the
+disadvantage that partial specializations are not possible.
 
 ## <A name="tracing"/> Tracing mocks
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -51,6 +51,7 @@
   - [`trompeloeil::matcher`](#matcher_type)
   - [`trompeloeil::mock_interface<T>`](#mock_interface)
   - [`trompeloeil::ok_reporter_func`](#ok_reporter_func)
+  - [`trompeloeil::printer`](#printer)
   - [`trompeloeil::reporter_func`](#reporter_func)
   - [`trompeloeil::sequence`](#sequence_type)
   - [`trompeloeil::severity`](#severity_type)
@@ -2042,6 +2043,27 @@ TEST(...)
 }
 ```
 
+### <A name="printer"/> `trompeloeil::printer<T>`
+
+`printer<T>` is a type that formats values to strings in reports from *Trompeloeil*.
+
+```Cpp
+template <typenme T>
+struct printer
+{
+  static void print(ostream& os, const T& t);
+};
+```
+
+By default the `print` function formats using `os << t`, provided the type `T`
+can be inserted into an `ostream`, otherwise it gives a hex-dump of the bytes
+occupied by the object.
+
+The type `trompeloeil::printer<T>` is a customization point that you can use
+to define string formatting for types that do not support `os << t`, or for
+which you  want a different representation in reports from *Trompeloeil*.
+See example in the [Cook Book](CookBook.md/#custom_formatting).
+
 ### <A name="reporter_func"/>`trompeloeil::reporter_func`
 
 A type used to pass information to the unit testing frame work that a call has
@@ -2238,13 +2260,16 @@ used by *Trompeloeil*. The mutex is held until the end of the scope.
 
 ### <A name="print"/>`trompeloeil::print(std::ostream& os, T const& t)`
 
-By default `print()` uses `os << t`, provided the type `T` can be
-inserted into an `ostream`. If not, it gives a hex-dump of the bytes
-occupied by the object.
+By default `print()` uses the type [`printer<T>`](#printer) to format
+data to strings.
 
 You can write specializations of
 `trompeloeil::print(std::ostream& os, T const& t)` for your own types
-`T`. See example in the [Cook Book](CookBook.md/#custom_formatting).
+`T`, but it is preferable to write a specialization of the type
+[`printer<T>`](#printer) instead, which also works for partial
+specializations.  See example in the
+[Cook Book](CookBook.md/#custom_formatting).
+
 
 ### <A name="is_null"/>`trompeloeil::is_null(T const&)`
 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1420,6 +1420,19 @@ template <typename T>
   };
 
   template <typename T>
+  struct printer
+  {
+    static
+    void
+    print(
+      std::ostream& os,
+      T const & t)
+    {
+      streamer<T>::print(os, t);
+    }
+  };
+
+  template <typename T>
   void
   print(
     std::ostream& os,
@@ -1431,7 +1444,7 @@ template <typename T>
     }
     else
     {
-      streamer<T>::print(os, t);
+      printer<T>::print(os, t);
     }
   }
 

--- a/test/compiling_tests.hpp
+++ b/test/compiling_tests.hpp
@@ -502,6 +502,15 @@ namespace nn
     os << "nn::print(TestOutput{" << p.n << "}";
   }
 
+  template <typename T>
+  struct wrapped
+  {
+    T value;
+    friend std::ostream& operator<<(std::ostream& os, const wrapped<T>& w)
+    {
+      return os << "wrapped(" << w.value << ')';
+    }
+  };
 } // namespace nn
 
 namespace trompeloeil
@@ -518,6 +527,7 @@ class TestOutputMock
 {
 public:
   MAKE_MOCK1(func, void(nn::TestOutput));
+  MAKE_MOCK1(func, void(nn::wrapped<int>));
 };
 
 class none

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4270,6 +4270,43 @@ TEST_CASE_METHOD(
   }
 }
 
+namespace trompeloeil {
+template<typename T>
+struct printer<nn::wrapped<T>>
+{
+  static void print(std::ostream &os, const nn::wrapped<T> &t)
+  {
+    os << "spec wrapped(";
+    trompeloeil::print(os, t.value);
+    os << ")";
+  }
+};
+}
+
+TEST_CASE_METHOD(
+  Fixture,
+  "C++11: failure on parameter on user template type is printed with custom printer",
+  "[C++11][C++14][streaming]"
+  )
+{
+  TestOutputMock m;
+  try
+  {
+    m.func(nn::wrapped<int>{3});
+    FAIL("didn't throw");
+  }
+  catch (reported)
+  {
+    REQUIRE(!reports.empty());
+    auto re = R":(No match for call of func with signature void\(nn::wrapped<int>\) with\.
+  param  _1 == spec wrapped\(3\)):";
+    auto& msg = reports.front().msg;
+    CAPTURE(msg);
+    REQUIRE(is_match(msg, re));
+  }
+
+}
+
 TEST_CASE_METHOD(
   Fixture,
   "C++11: A null-comparable object is printed as 'nullptr' if equal",


### PR DESCRIPTION
Specializing `trompeloeil::print(ostream&, const T&)` is insufficient because function templates cannot be partially specialized, and overloads are resolved too early to be found. A class template `trompeloeil::printer<T>` is introduced as a preferred customization point, which does allow partial specializations.

Want to have a look @AndrewPaxie ? I'm reasonably confident about the implementation (although I'm sure it can be improved,) but less confident about the quality of the docs.