### PR TITLE
Verifies calls that are expected after an object dies

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -2916,6 +2916,12 @@ template <typename T>
     {
       died = true;
       sequences->validate(severity::nonfatal, call_name, loc);
+
+      sequences->increment_call();
+      if (sequences->is_satisfied())
+      {
+        sequences->retire_predecessors();
+      }
     }
 
     template <typename ... T>

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4890,6 +4890,23 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
+  "C++11: require destruction fulfilled in sequence with another object is not reported",
+  "[C++11][C++14][deathwatched][sequences]")
+{
+  auto obj = new trompeloeil::deathwatched<mock_c>;
+  mock_c obj2;
+  trompeloeil::sequence s;
+  REQUIRE_DESTRUCTION(*obj)
+    .IN_SEQUENCE(s);
+  REQUIRE_CALL_V(obj2, foo("foo"),
+    .IN_SEQUENCE(s));
+  delete obj;
+  obj2.foo("foo");
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+  Fixture,
   "C++11: named require destruction fulfilled in sequence is not reported",
   "[C++11][C++14][deathwatched][sequences]")
 {

--- a/test/compiling_tests_14.cpp
+++ b/test/compiling_tests_14.cpp
@@ -4185,6 +4185,23 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
+    Fixture,
+    "C++14: require destruction fulfilled in sequence with another object is not reported",
+    "[C++14][deathwatched][sequences]")
+{
+  auto obj = new trompeloeil::deathwatched<mock_c>;
+  mock_c obj2;
+  trompeloeil::sequence s;
+  REQUIRE_DESTRUCTION(*obj)
+    .IN_SEQUENCE(s);
+  REQUIRE_CALL(obj2, foo("foo"))
+    .IN_SEQUENCE(s);
+  delete obj;
+  obj2.foo("foo");
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
   Fixture,
   "C++14: named require destruction fulfilled in sequence is not reported",
   "[C++14][deathwatched][sequences]")


### PR DESCRIPTION
Sequence calls are not retired when a deathwatched object is destroyed. This means that subsquent IN_SEQUENCE assertions on other objects are not honoured

Minimal bug repro: https://godbolt.org/z/Y7sWb163K

This PR resolves this issue

Hopefully the style is consistent with existing code. I couldn't find a clang-format or similar guidance. If the test name is too long, or if there are any other problems with this PR, please let me know :)