### PR TITLE
Resolve lingering warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,14 +161,6 @@ if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
                " -Wno-extra-semi-stmt")
       endif()
 
-      check_cxx_compiler_flag("-Wno-zero-as-null-pointer-constant" WARN_ZERO_NULL)
-
-      if (WARN_ZERO_NULL)
-        string(APPEND
-               WARN_FLAGS
-               " -Wno-zero-as-null-pointer-constant")
-      endif()
-
       # Disable for Catch2.
       # See <https://github.com/catchorg/Catch2/issues/578>
       check_cxx_compiler_flag("-Wno-reserved-identifier" WARN_RESERVED_ID)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
-	* Fix issue 250: Warnings about zero argument variadic macros with?
+	* Fix issue 253: Resolve lingering warnings in early Clang compilers and
+	  enable -Wzero-as-null-pointer-constant when compiling unit tests with
+	  GCC and Clang.
+
+	* Fix issue 250: Warnings about zero argument variadic macros with
 	  clang-msvc. Thanks u3shit for reporting and fixing.
 
 	* Fix issue 251: trompeloeil::printer<> customization point now supports
@@ -7,7 +11,7 @@
 
 	* Fix issue 245: Modify cmake to build thread_terror on Windows with MSVC.
 
-    * Use CMake internal Threads::Threads target where needed
+	* Use CMake internal Threads::Threads target where needed
 
 v41 2021-06-15
 

--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1119,7 +1119,7 @@ template <typename T>
   template <typename T>
   struct typed_matcher : matcher
   {
-    operator T() const;
+    operator T() const { return {}; }
   };
 
   template <>
@@ -1148,7 +1148,7 @@ template <typename T>
     template <typename V,
               typename = detail::enable_if_t<!is_matcher<V>{}>,
               typename = invoke_result_type<Pred, V&&, T...>>
-    operator V&&() const;
+    operator V&&() const { return *this; }
 
 #endif
 
@@ -2100,7 +2100,7 @@ template <typename T>
   public:
     template <typename U,
               typename = decltype(can_match_parameter<detail::remove_reference_t<decltype(std::declval<U>())>>(std::declval<M>()))>
-    operator U() const;
+    operator U() const { return {}; }
 
     template <typename U>
     explicit

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4018,11 +4018,20 @@ Tried obj\.foo\(not_empty\{\}\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*
 
 namespace
 {
-
+  /*
+   * Prefer the expression
+   * 'x.compare(min) >= 0 && x.compare(max) <= 0'
+   * to the more natural
+   * 'x >= min && x <= max'
+   * to avoid a warning in the configuration
+   * Clang and (10.0.0 <= version < 12.0.0) and C++20 mode and
+   * libstdc++v3 released with GCC version 10.
+   * See: https://bugs.llvm.org/show_bug.cgi?id=44325 .
+   */
   auto cxx11_is_clamped_lambda =
     [](std::string x, std::string min, std::string max)
-      -> decltype(x >= min && x <= max) {
-      return x >= min && x <= max;
+      -> decltype(x.compare(min) >= 0 && x.compare(max) <= 0) {
+      return x.compare(min) >= 0 && x.compare(max) <= 0;
     };
 
   auto cxx11_is_clamped_printer =


### PR DESCRIPTION
- In early Clang compilers and
- Enable -Wzero-as-null-pointer-constant when compiling unit tests with
  GCC and Clang.