### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.14)
 project(trompeloeil)
 
 include(GNUInstallDirs)
@@ -39,7 +39,7 @@ option(TROMPELOEIL_INSTALL_DOCS "Install documentation" ${TROMPELOEIL_INSTALL_TA
 
 if (MASTER_PROJECT AND CMAKE_BUILD_TYPE MATCHES Debug)
 
-  option(TROMPELOEIL_CATCH2_PREBUILT "Major ersion of prebuilt catch2")
+  option(TROMPELOEIL_CATCH2_PREBUILT "Major version of prebuilt catch2")
   option(TROMPELOEIL_CATCH2_PREFIX "Path to catch2 installation")
 
   if (${CXX_STANDARD})


### PR DESCRIPTION
Update minimum cmake version to v3.14. Fixes issue #284 


Alternatively, if the minimum version needs to stay at v3.2, the newer features can be conditionally used. eg
```diff
+set(arch_ind "")
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.14)
+    set(arch_ind ARCH_INDEPENDENT)
+endif()
+
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/trompeloeil/trompeloeil-config-version.cmake"
   VERSION 43
   COMPATIBILITY AnyNewerVersion
-  ARCH_INDEPENDENT)
+  ${arch_ind})
 
 add_library(trompeloeil INTERFACE)
 add_library(trompeloeil::trompeloeil ALIAS trompeloeil)
```