### PR TITLE
fix: parenthesized return type [#164]

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -922,7 +922,7 @@ like this:
 ```Cpp
 struct M
 {
-  MAKE_MOCK2(make, (std::pair<int,int>(int,int)));
+  MAKE_MOCK2(make, (std::pair<int,int>)(int,int));
 };
 ```
 


### PR DESCRIPTION
Hi there,

I just fix up a mistakenly placed parentheses in the doc (https://github.com/rollbear/trompeloeil/issues/164#issuecomment-536558049).