### PR TITLE
Fix syntax error in cookbook example

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -2079,7 +2079,7 @@ which creates the matcher.
 
       // stored value
       std::vector<int>(elements)
-    )
+    );
   }
 ```
 


### PR DESCRIPTION
There's a `;` missing in the example.