### PR TITLE
On seq mismatch, report first in line and first required

### DIFF
--- a/include/trompeloeil.hpp
+++ b/include/trompeloeil.hpp
@@ -1981,6 +1981,11 @@ template <typename T>
       const
       noexcept;
 
+    bool
+    is_optional()
+      const
+      noexcept;
+
     void
     retire()
     noexcept
@@ -2098,17 +2103,37 @@ template <typename T>
          << "\" has no more pending expectations\n";
       send_report<specialized>(s, loc, os.str());
     }
+    bool first = true;
+    std::ostringstream os;
+    os << "Sequence mismatch for sequence \"" << seq_name
+       << "\" with matching call of " << match_name
+       << " at " << loc << ".\n";
     for (auto const& m : matchers)
     {
-      std::ostringstream os;
-      os << "Sequence mismatch for sequence \"" << seq_name
-         << "\" with matching call of " << match_name
-         << " at " << loc
-         << ". Sequence \"" << seq_name << "\" has ";
-      m.print_expectation(os);
-      os << " first in line\n";
-      send_report<specialized>(s, loc, os.str());
+      if (first || !m.is_optional())
+      {
+        if (first)
+        {
+          os << "Sequence \"" << seq_name << "\" has ";
+        }
+        else
+        {
+          os << "and has ";
+        }
+        m.print_expectation(os);
+        if (m.is_optional())
+        {
+          os << " first in line\n";
+        }
+        else
+        {
+          os << " as first required expectation\n";
+          break;
+        }
+      }
+      first = false;
     }
+    send_report<specialized>(s, loc, os.str());
   }
 
   inline
@@ -2828,6 +2853,15 @@ template <typename T>
   noexcept
   {
     return sequence_handler.is_satisfied();
+  }
+
+  inline
+  bool
+  sequence_matcher::is_optional()
+  const
+  noexcept
+  {
+    return sequence_handler.get_min_calls() == 0;
   }
 
   template <size_t N>

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -243,7 +243,7 @@ TEST_CASE_METHOD(
   }
   catch (reported)
   {
-    auto re = R":(Sequence mismatch.*\"seq2\".*matching.*obj.func\(_,_\).*has obj.count\(\) at.*first):";
+    auto re = R":(Sequence mismatch.*\"seq2\".*matching.*obj.func\(_,_\).*\nSequence.*has obj.count\(\) at.*first):";
     auto& msg = reports.front().msg;
     INFO("msg=" << msg);
     REQUIRE(is_match(msg, re));
@@ -309,7 +309,7 @@ TEST_CASE_METHOD(
   catch (reported)
   {
     REQUIRE(!reports.empty());
-    auto re = R":(Sequence mismatch.*\"seq\".*matching.*obj2.count\(\).*has obj2\.func\(_,_\) at.*first):";
+    auto re = R":(Sequence mismatch.*\"seq\".*matching.*obj2.count\(\).*\n.*has obj2\.func\(_,_\) at.*first):";
     REQUIRE(is_match(reports.front().msg, re));
   }
 }
@@ -348,7 +348,7 @@ TEST_CASE_METHOD(
   catch (reported)
   {
     REQUIRE(!reports.empty());
-    auto re = R":(Sequence mismatch.*seq2.*of obj2\.count\(\).*has obj1.count\(\).*first):";
+    auto re = R":(Sequence mismatch.*seq2.*of obj2\.count\(\).*\n.*has obj1.count\(\).*first):";
     REQUIRE(is_match(reports.front().msg, re));
   }
 }
@@ -471,7 +471,7 @@ TEST_CASE_METHOD(
   catch (reported)
   {
     REQUIRE(reports.size() >= 1U);
-    auto re = R":(Sequence mismatch.*seq.*of obj\.count\(\).*has obj\.func\(_, _\).*first):";
+    auto re = R":(Sequence mismatch.*seq.*of obj\.count\(\).*\nSequence.*has obj\.func\(_, _\).*first):";
     INFO("report=" << reports.front().msg);
     REQUIRE(is_match(reports.front().msg,  re));
   }
@@ -637,7 +637,7 @@ TEST_CASE_METHOD(
   }
   catch (reported)
   {
-    auto re = R":(Sequence mismatch.*seq.*of obj\.getter\(2\).*has obj\.getter\(3\).*first):";
+    auto re = R":(Sequence mismatch.*seq.*of obj\.getter\(2\).*\nSequence.*has obj\.getter\(3\).*first):";
     INFO("report=" << reports.front().msg);
     REQUIRE(is_match(reports.front().msg,  re));
     auto& first = reports.front();
@@ -674,7 +674,7 @@ TEST_CASE_METHOD(
   }
   catch (reported)
   {
-    auto re = R":(Sequence mismatch.*seq.*of obj\.getter\(1\).*has obj\.getter\(3\).*first):";
+    auto re = R":(Sequence mismatch.*seq.*of obj\.getter\(1\).*\nSequence.*has obj\.getter\(3\).*first):";
     INFO("report=" << reports.front().msg);
     REQUIRE(is_match(reports.front().msg,  re));
     auto& first = reports.front();
@@ -741,7 +741,7 @@ TEST_CASE_METHOD(
   catch (reported)
   {
     REQUIRE(reports.size() == 1U);
-    auto re = R":(Sequence mismatch.*seq1.*of obj1\.func\(_, _\).*has obj1\.count\(\).*first):";
+    auto re = R":(Sequence mismatch.*seq1.*of obj1\.func\(_, _\).*\nSequence.*has obj1\.count\(\).*first):";
     INFO("report=" << reports.front().msg);
     REQUIRE(is_match(reports.front().msg,  re));
     auto& first = reports.front();
@@ -5044,7 +5044,8 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
+.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(is_match(msg, re));
 }
@@ -5069,7 +5070,8 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*Sequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
+Sequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(is_match(msg, re));
   }
@@ -5089,7 +5091,8 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
+.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(is_match(msg, re));
 }
@@ -5114,7 +5117,8 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*Sequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
+Sequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(is_match(msg, re));
   }

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -5044,8 +5044,7 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*\n.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(is_match(msg, re));
 }
@@ -5070,8 +5069,7 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-Sequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*\nSequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(is_match(msg, re));
   }
@@ -5091,8 +5089,7 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*\n.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(is_match(msg, re));
 }
@@ -5117,8 +5114,7 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-Sequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*\nSequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(is_match(msg, re));
   }

--- a/test/compiling_tests_14.cpp
+++ b/test/compiling_tests_14.cpp
@@ -4361,8 +4361,7 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*\n.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(std::regex_search(msg, std::regex(re)));
 }
@@ -4387,8 +4386,7 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-Sequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*\nSequence.* REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(std::regex_search(msg, std::regex(re)));
   }
@@ -4408,8 +4406,7 @@ TEST_CASE_METHOD(
   delete obj;
   REQUIRE(!reports.empty());
   auto& msg = reports.front().msg;
-  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-.*foo"):";
+  auto re = R":(Sequence mismatch for sequence "s".*destructor for \*obj at [A-Za-z0-9_ ./:\]*:[0-9]*.*\n.*foo"):";
   INFO("msg=" << msg);
   REQUIRE(std::regex_search(msg, std::regex(re)));
 }
@@ -4434,8 +4431,7 @@ TEST_CASE_METHOD(
   {
     REQUIRE(!reports.empty());
     auto& msg = reports.front().msg;
-    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*\.
-Sequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
+    auto re = R":(Sequence mismatch for sequence "s".*\*obj.foo\("foo"\) at [A-Za-z0-9_ ./:\]*:[0-9]*.*\nSequence.* NAMED_REQUIRE_DESTRUCTION\(\*obj\)):";
     INFO("msg=" << msg);
     REQUIRE(std::regex_search(msg, std::regex(re)));
   }


### PR DESCRIPTION
@AndrewPaxie can you have a look and see if you understand why the regular expressions for sequence matching fail on the Windows builds? I assume it has something to do with line breaks, but I don't understand how. I've tried with explicit '\n' and the current shape with line breaks in the literal string source, hoping it'd become "\r\n".