### PR TITLE
fix example code in documentation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -234,7 +234,7 @@ public:
   MAKE_MOCK1(func, int(int));
 };
 
-trompeloeil::_;
+using trompeloeil::_;
 
 TEST(atest)
 {
@@ -661,7 +661,7 @@ public:
   MAKE_MOCK1(func, int(int));
 };
 
-trompeloeil::_;
+using trompeloeil::_;
 
 TEST(atest)
 {


### PR DESCRIPTION
Some `using` keywords are missing in the code examples in the documentation.