### PR TITLE
Specify project LANGUAGES in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(trompeloeil)
+project(trompeloeil CXX)
 
 include(GNUInstallDirs)
 include(ExternalProject)


### PR DESCRIPTION
If Trompeloeil is included into a project using `ExternalProject_Add` or the `FetchContent` module it will cause CMake to attempt to detect a C compiler, which is undesirable for projects that are written in pure C++.  This is due the default behavior of the `project` command when `LANGUAGES` is not specified.

This PR addresses the issue by specifying `CXX` in the `project` call, which prevents automatic compiler detection for C.