### PR TITLE
Matchers should receive non-const parameters when possible

### DIFF
--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -1000,6 +1000,15 @@ template <typename T>
   }
 
   template <typename T>
+  constexpr
+  bool
+  is_null(
+    std::reference_wrapper<T> t)
+  {
+    return is_null(t.get());
+  }
+
+  template <typename T>
   void
   print(
     std::ostream& os,

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -1850,7 +1850,7 @@ template <typename T>
   template <typename R, typename ... T>
   struct call_params_type<R(T...)>
   {
-    using type = std::tuple<std::reference_wrapper<std::remove_reference_t<T>>...>;
+    using type = std::tuple<std::reference_wrapper<detail::remove_reference_t<T>>...>;
   };
 
   template <typename T>

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -1152,6 +1152,20 @@ template <typename T>
       os << " matching _";
     }
   };
+
+  template <typename T>
+  struct printer<std::reference_wrapper<T>>
+  {
+    static
+    void
+    print(
+    std::ostream& os,
+    std::reference_wrapper<T> ref)
+    {
+        ::trompeloeil::print(os, ref.get());
+    }
+  };
+
   template <typename T>
   void
   print(
@@ -1836,7 +1850,7 @@ template <typename T>
   template <typename R, typename ... T>
   struct call_params_type<R(T...)>
   {
-    using type = std::tuple<typename std::add_lvalue_reference<T>::type...>;
+    using type = std::tuple<std::reference_wrapper<std::remove_reference_t<T>>...>;
   };
 
   template <typename T>
@@ -1970,11 +1984,11 @@ template <typename T>
   bool
   param_matches_impl(
     T const& t,
-    U const& u,
+    std::reference_wrapper<U> u,
     matcher const*)
-  noexcept(noexcept(t.matches(u)))
+  noexcept(noexcept(t.matches(u.get())))
   {
-    return t.matches(u);
+    return t.matches(u.get());
   }
 
   template <typename T,
@@ -2005,11 +2019,11 @@ template <typename T>
   bool
   param_matches_impl(
     T const& t,
-    U const& u,
+    std::reference_wrapper<U> u,
     void const*)
-  noexcept(noexcept(::trompeloeil::identity<U>(t) == u))
+  noexcept(noexcept(::trompeloeil::identity<U>(t) == u.get()))
   {
-    return ::trompeloeil::identity<U>(t) == u;
+    return ::trompeloeil::identity<U>(t) == u.get();
   }
 
   template <typename T, typename U>
@@ -3072,7 +3086,7 @@ template <typename T>
     int N,
     typename T,
     typename = detail::enable_if_t<N <= std::tuple_size<T>::value>,
-    typename R = decltype(std::get<N-1>(std::declval<T>()))
+    typename R = decltype(std::get<N-1>(std::declval<T>()).get())
   >
   constexpr
   TROMPELOEIL_DECLTYPE_AUTO
@@ -3081,7 +3095,7 @@ template <typename T>
     std::true_type)
   TROMPELOEIL_TRAILING_RETURN_TYPE(R)
   {
-    return std::get<N-1>(*t);
+    return std::get<N-1>(*t).get();
   }
 
   template <int>

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -1397,6 +1397,29 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
+  "C++11: Matchers receive parameters as lvalue-reference.",
+  "[C++11][C++14][matching]")
+{
+  const auto matcher = trompeloeil::make_matcher<trompeloeil::wildcard>(
+	[](int& value)
+	{
+	  return value == 42;
+	},
+	[](std::ostream&)
+	{
+	});
+
+  {
+    U u;
+    REQUIRE_CALL_V(u, func_lr(matcher));
+    int x = 42;
+	u.func_lr(x);
+  }
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+  Fixture,
   "C++11: An uncomparable but constructible type by reference matches a call",
   "[C++11][C++14][matching]")
 {

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -1413,7 +1413,7 @@ TEST_CASE_METHOD(
     U u;
     REQUIRE_CALL_V(u, func_lr(matcher));
     int x = 42;
-	u.func_lr(x);
+    u.func_lr(x);
   }
   REQUIRE(reports.empty());
 }


### PR DESCRIPTION
When working with matchers, I often stumble across a minor inconvenience when using matchers directly as a REQUIRE_CALL parameter.
Given the following situation:
```c++
struct Mock
{
    MAKE_MOCK1(foo, void(int));
};
```
``foo`` does not imply any restrictions on its param (it's a non-const value), but still any matchers receive it as const-ref => this custom matcher does not compile:
```cpp
const auto matcher = trompeloeil::make_matcher<trompeloeil::wildcard>(
	[](int& value)
	{
 return value == 42;
	},
	[](std::ostream&)
	{
	});
```
As its usually good style to provide read-only arguments as const-ref, this has some implications what we can actually check. In my case its the ``ranges::any_view`` from ``range-v3`` lib, which is actually unusable when constraint with const, as ``empty``, ``begin`` and ``end`` members are not const overloaded. 
Nevertheless there is sometimes the necessity to apply matchers on non-const refs, which currently is not directly supported. As the placeholders (``_1``, ...) do not promote to const, I can of course check with an ``WITH`` statement, but that seems just like a workaround to me.
The issue is, that you put each param into a tuple of references, but then pass the tuple around as const-ref, which then is supplied into ``std::get``, which actually does the const promotion on the elements. That's a pitty, but instead of creating a tuple of lvalue-refs, we can switch to a tuple of ``std::reference_wrapper`` and unwrap those where necessary.