### PR TITLE
add runtime ``TIMES``

### DIFF
--- a/compilation_errors/mixed_limits_with_rt_limits.cpp
+++ b/compilation_errors/mixed_limits_with_rt_limits.cpp
@@ -26,14 +26,14 @@ int main()
 #if (TROMPELOEIL_CPLUSPLUS == 201103L)
 
   REQUIRE_CALL_V(obj, f(),
-    .RT_TIMES(AT_LEAST(1))
+    .TIMES(AT_LEAST(1))
     .RT_TIMES(AT_MOST(3))
     .RETURN(0));
 
 #else /* (TROMPELOEIL_CPLUSPLUS == 201103L) */
 
   REQUIRE_CALL(obj, f())
-    .RT_TIMES(AT_LEAST(1))
+    .TIMES(AT_LEAST(1))
     .RT_TIMES(AT_MOST(3))
     .RETURN(0);
 

--- a/compilation_errors/mixed_rt_limits_with_limits.cpp
+++ b/compilation_errors/mixed_rt_limits_with_limits.cpp
@@ -26,15 +26,15 @@ int main()
 #if (TROMPELOEIL_CPLUSPLUS == 201103L)
 
   REQUIRE_CALL_V(obj, f(),
-    .TIMES(AT_LEAST(1))
-    .RT_TIMES(AT_MOST(3))
+    .RT_TIMES(AT_LEAST(1))
+    .TIMES(AT_MOST(3))
     .RETURN(0));
 
 #else /* (TROMPELOEIL_CPLUSPLUS == 201103L) */
 
   REQUIRE_CALL(obj, f())
-    .TIMES(AT_LEAST(1))
-    .RT_TIMES(AT_MOST(3))
+    .RT_TIMES(AT_LEAST(1))
+    .TIMES(AT_MOST(3))
     .RETURN(0);
 
 #endif /* !(TROMPELOEIL_CPLUSPLUS == 201103L) */

--- a/compilation_errors/multiple_rt_limits.cpp
+++ b/compilation_errors/multiple_rt_limits.cpp
@@ -1,0 +1,41 @@
+/*
+ * Trompeloeil C++ mocking framework
+ *
+ * Copyright Björn Fahller
+ *
+ *  Use, modification and distribution is subject to the
+ *  Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * Project home: https://github.com/rollbear/trompeloeil
+ */
+
+// pass: Only one TIMES call limit is allowed, but it can express an interval
+#include <trompeloeil.hpp>
+
+struct MS
+{
+  MAKE_MOCK0(f, int());
+};
+
+int main()
+{
+  MS obj;
+
+#if (TROMPELOEIL_CPLUSPLUS == 201103L)
+
+  REQUIRE_CALL_V(obj, f(),
+    .RT_TIMES(AT_LEAST(1))
+    .RT_TIMES(AT_MOST(3))
+    .RETURN(0));
+
+#else /* (TROMPELOEIL_CPLUSPLUS == 201103L) */
+
+  REQUIRE_CALL(obj, f())
+    .RT_TIMES(AT_LEAST(1))
+    .RT_TIMES(AT_MOST(3))
+    .RETURN(0);
+
+#endif /* !(TROMPELOEIL_CPLUSPLUS == 201103L) */
+}

--- a/compilation_errors/multiple_rt_limits_and_ct_limits.cpp
+++ b/compilation_errors/multiple_rt_limits_and_ct_limits.cpp
@@ -1,0 +1,41 @@
+/*
+ * Trompeloeil C++ mocking framework
+ *
+ * Copyright Björn Fahller
+ *
+ *  Use, modification and distribution is subject to the
+ *  Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * Project home: https://github.com/rollbear/trompeloeil
+ */
+
+// pass: Only one TIMES call limit is allowed, but it can express an interval
+#include <trompeloeil.hpp>
+
+struct MS
+{
+  MAKE_MOCK0(f, int());
+};
+
+int main()
+{
+  MS obj;
+
+#if (TROMPELOEIL_CPLUSPLUS == 201103L)
+
+  REQUIRE_CALL_V(obj, f(),
+    .TIMES(AT_LEAST(1))
+    .RT_TIMES(AT_MOST(3))
+    .RETURN(0));
+
+#else /* (TROMPELOEIL_CPLUSPLUS == 201103L) */
+
+  REQUIRE_CALL(obj, f())
+    .TIMES(AT_LEAST(1))
+    .RT_TIMES(AT_MOST(3))
+    .RETURN(0);
+
+#endif /* !(TROMPELOEIL_CPLUSPLUS == 201103L) */
+}

--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -1734,8 +1734,9 @@ control with the Trompeloeil C\+\+14 Mocking Framework](http://playfulprogrammin
 
 By default [**`REQUIRE_CALL(...)`**](reference.md/#REQUIRE_CALL) needs exactly
 one matching call, otherwise a violation is reported. Sometimes the need is
-for something else. A modifier [**`TIMES(...)`**](reference.md/#TIMES) is used
-to change that. You can either specify an exact number of times matching calls
+for something else. The modifiers [**`TIMES(...)`**](reference.md/#TIMES-and-RT_TIMES) or
+[**`RT_TIMES(...)`**](reference.md/#TIMES-and-RT_TIMES) can be used to change that.
+You can either specify an exact number of times matching calls
 must be made, or a range of numbers.
 
 Example:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2096,7 +2096,7 @@ Above, **`THROW(...)`** will refer to a copy of the string `what` with the value
 
 See also [**`LR_THROW(...)`**](#LR_THROW) which accesses copies of local objects.
 
-<A name="TIMES and RT_TIMES"/>
+<A name="TIMES-and-RT_TIMES"/>
 
 ### **`TIMES(`** *limits* **`)`** and **`RT_TIMES(`** *limits* **`)`**
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,9 +47,10 @@
   - [**`REQUIRE_CALL(`** *mock_object*, *func_name*(*parameter_list*)**`)`**](#REQUIRE_CALL)
   - [**`REQUIRE_DESTRUCTION(`** *mock_object* **`)`**](#REQUIRE_DESTRUCTION)
   - [**`RETURN(`** *expr* **`)`**](#RETURN)
+  - [**`RT_TIMES(`** *limit* **`)`**](#TIMES-and-RT_TIMES)
   - [**`SIDE_EFFECT(`** *expr* **`)`**](#SIDE_EFFECT)
   - [**`THROW(`** *expr* **`)`**](#THROW)
-  - [**`TIMES(`** *limit* **`)`**](#TIMES)
+  - [**`TIMES(`** *limit* **`)`**](#TIMES-and-RT_TIMES)
   - [**`WITH(`** *expr* **`)`**](#WITH)
 - [Types and Type Templates](#types_and_templates) (alphabetical order)
   - [`trompeloeil::deathwatched<T>`](#deathwatched_type)
@@ -2095,9 +2096,9 @@ Above, **`THROW(...)`** will refer to a copy of the string `what` with the value
 
 See also [**`LR_THROW(...)`**](#LR_THROW) which accesses copies of local objects.
 
-<A name="TIMES"/>
+<A name="TIMES and RT_TIMES"/>
 
-### **`TIMES(`** *limits* **`)`**
+### **`TIMES(`** *limits* **`)`** and **`RT_TIMES(`** *limits* **`)`**
 
 Used in [**`REQUIRE_CALL(...)`**](#REQUIRE_CALL) and
 [**`NAMED_REQUIRE_CALL(...)`**](#NAMED_REQUIRE_CALL) to set the limits on
@@ -2109,15 +2110,19 @@ matching calls required.
 *limits* may also be two numbers, describing a range *min-inclusive*,
 *max-inclusive*.
 
-If the minimum number of matching calls in not met before the end of the
+If the minimum number of matching calls is not met before the end of the
 lifetime of the [expectation](#expectation), a violation is reported.
 
 If the maximum number of matching calls is exceeded, a violation is reported.
 
-*limits* must be
-[`constexpr`](http://en.cppreference.com/w/cpp/language/constexpr).
+The difference between **`TIMES(...)`** and **`RT_TIMES(...)`** is, that the
+prior only supports [`constexpr`](http://en.cppreference.com/w/cpp/language/constexpr)
+arguments, while the latter is designed to accept also runtime arguements.
+If invalid bounds are provided, **`TIMES(...)`** issues a compile-error.
+**`RT_TIMES(...)`** will compile successfully, but will raise a ``std::logic_error``
+during construction.
 
-**`TIMES(...)`** may only be used once for each
+Either a single **`TIMES(...)`** or **`RT_TIMES(...)`** may be used for each
 [**`REQUIRE_CALL(..)`**](#REQUIRE_CALL) or
 [**`NAMED_REQUIRE_CALL(...)`**](#NAMED_REQUIRE_CALL).
 
@@ -2151,7 +2156,8 @@ See also the helpers [**`AT_LEAST(...)`**](#AT_LEAST) and
 [**`AT_MOST(...)`**](#AT_MOST).
 
 See also [**`IN_SEQUENCE(...)`**](#IN_SEQUENCE) for information about how
-`.TIMES(...)` works together with [**`sequence`**](#sequence_type) objects.
+`.TIMES(...)` and `.RT_TIMES(...)` work together with [**`sequence`**](#sequence_type)
+objects.
 
 <A name="WITH"/>
 

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2506,18 +2506,18 @@ template <typename T>
   template <size_t L, size_t H = L>
   struct multiplicity { };
 
-  struct dynamic_multiplicity
+  struct rt_multiplicity
   {
 	  std::size_t low{};
 	  std::size_t high{};
 
-    explicit dynamic_multiplicity(std::size_t _low) noexcept
+    explicit rt_multiplicity(std::size_t _low) noexcept
 	    : low{_low},
 		high{_low}
     {
     }
 
-    explicit dynamic_multiplicity(std::size_t _low, std::size_t _high) noexcept
+    explicit rt_multiplicity(std::size_t _low, std::size_t _high) noexcept
 	    : low{_low},
 		high{_high}
     {
@@ -2827,7 +2827,7 @@ template <typename T>
     static
     call_modifier<Matcher, modifier_tag, call_limit_injector<Parent, std::numeric_limits<std::size_t>::max()>>
     action(call_modifier<Matcher, modifier_tag, Parent>&& m,
-           dynamic_multiplicity bounds)
+           rt_multiplicity bounds)
     {
       static_assert(!times_set,
                     "Only one RT_TIMES call limit is allowed, but it can express an interval");
@@ -4165,7 +4165,7 @@ template <typename T>
 
 
 #define TROMPELOEIL_TIMES(...) template action<trompeloeil::times>(::trompeloeil::multiplicity<__VA_ARGS__>{})
-#define TROMPELOEIL_RT_TIMES(...) template action<trompeloeil::runtime_times>(::trompeloeil::dynamic_multiplicity{__VA_ARGS__})
+#define TROMPELOEIL_RT_TIMES(...) template action<trompeloeil::runtime_times>(::trompeloeil::rt_multiplicity{__VA_ARGS__})
 #define TROMPELOEIL_INFINITY_TIMES() TROMPELOEIL_TIMES(0, ~static_cast<size_t>(0))
 
 #define TROMPELOEIL_AT_LEAST(num) num, ~static_cast<size_t>(0)

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2511,7 +2511,13 @@ template <typename T>
 	  std::size_t low{};
 	  std::size_t high{};
 
-    explicit dynamic_multiplicity(std::size_t _low, std::size_t _high = _low) noexcept
+    explicit dynamic_multiplicity(std::size_t _low) noexcept
+	    : low{_low},
+		high{_low}
+    {
+    }
+
+    explicit dynamic_multiplicity(std::size_t _low, std::size_t _high) noexcept
 	    : low{_low},
 		high{_high}
     {

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2819,7 +2819,7 @@ template <typename T>
     }
   };
 
-  struct dynamic_times
+  struct runtime_times
   {
     template <
       typename Matcher, typename modifier_tag, typename Parent,
@@ -2830,11 +2830,11 @@ template <typename T>
            dynamic_multiplicity bounds)
     {
       static_assert(!times_set,
-                    "Only one DYN_TIMES call limit is allowed, but it can express an interval");
+                    "Only one RT_TIMES call limit is allowed, but it can express an interval");
 
       if (bounds.high < bounds.low)
       {
-	      throw std::logic_error{"In DYN_TIMES the first value must not exceed the second"};
+	      throw std::logic_error{"In RT_TIMES the first value must not exceed the second"};
       }
 
       m.matcher->sequences->set_limits(bounds.low, bounds.high);
@@ -4165,7 +4165,7 @@ template <typename T>
 
 
 #define TROMPELOEIL_TIMES(...) template action<trompeloeil::times>(::trompeloeil::multiplicity<__VA_ARGS__>{})
-#define TROMPELOEIL_DYN_TIMES(...) template action<trompeloeil::dynamic_times>(::trompeloeil::dynamic_multiplicity{__VA_ARGS__})
+#define TROMPELOEIL_RT_TIMES(...) template action<trompeloeil::runtime_times>(::trompeloeil::dynamic_multiplicity{__VA_ARGS__})
 #define TROMPELOEIL_INFINITY_TIMES() TROMPELOEIL_TIMES(0, ~static_cast<size_t>(0))
 
 #define TROMPELOEIL_AT_LEAST(num) num, ~static_cast<size_t>(0)
@@ -4302,7 +4302,7 @@ template <typename T>
 #define THROW                     TROMPELOEIL_THROW
 #define LR_THROW                  TROMPELOEIL_LR_THROW
 #define TIMES                     TROMPELOEIL_TIMES
-#define DYN_TIMES                 TROMPELOEIL_DYN_TIMES
+#define RT_TIMES                  TROMPELOEIL_RT_TIMES
 #define AT_LEAST                  TROMPELOEIL_AT_LEAST
 #define AT_MOST                   TROMPELOEIL_AT_MOST
 

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2506,6 +2506,12 @@ template <typename T>
   template <size_t L, size_t H = L>
   struct multiplicity { };
 
+  struct dynamic_multiplicity
+  {
+	  std::size_t low{};
+	  std::size_t high{low};
+  };
+
   template <typename R, typename Parent>
   struct co_return_injector : Parent
   {
@@ -2798,6 +2804,29 @@ template <typename T>
 
       m.matcher->sequences->set_limits(L, H);
       return {std::move(m).matcher};
+    }
+  };
+
+  struct dynamic_times
+  {
+    template <
+      typename Matcher, typename modifier_tag, typename Parent,
+      bool times_set = Parent::call_limit_set>
+    static
+    call_modifier<Matcher, modifier_tag, call_limit_injector<Parent, std::numeric_limits<std::size_t>::max()>>
+    action(call_modifier<Matcher, modifier_tag, Parent>&& m,
+           dynamic_multiplicity bounds)
+    {
+      static_assert(!times_set,
+                    "Only one DYN_TIMES call limit is allowed, but it can express an interval");
+
+      if (bounds.high < bounds.low)
+      {
+	      throw std::logic_error{"In DYN_TIMES the first value must not exceed the second"};
+      }
+
+      m.matcher->sequences->set_limits(bounds.low, bounds.high);
+      return {m.matcher};
     }
   };
 
@@ -4124,6 +4153,7 @@ template <typename T>
 
 
 #define TROMPELOEIL_TIMES(...) template action<trompeloeil::times>(::trompeloeil::multiplicity<__VA_ARGS__>{})
+#define TROMPELOEIL_DYN_TIMES(...) template action<trompeloeil::dynamic_times>(::trompeloeil::dynamic_multiplicity{__VA_ARGS__})
 #define TROMPELOEIL_INFINITY_TIMES() TROMPELOEIL_TIMES(0, ~static_cast<size_t>(0))
 
 #define TROMPELOEIL_AT_LEAST(num) num, ~static_cast<size_t>(0)
@@ -4260,6 +4290,7 @@ template <typename T>
 #define THROW                     TROMPELOEIL_THROW
 #define LR_THROW                  TROMPELOEIL_LR_THROW
 #define TIMES                     TROMPELOEIL_TIMES
+#define DYN_TIMES                 TROMPELOEIL_DYN_TIMES
 #define AT_LEAST                  TROMPELOEIL_AT_LEAST
 #define AT_MOST                   TROMPELOEIL_AT_MOST
 

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2838,7 +2838,7 @@ template <typename T>
       }
 
       m.matcher->sequences->set_limits(bounds.low, bounds.high);
-      return {m.matcher};
+      return std::move(m).matcher;
     }
   };
 

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2509,7 +2509,13 @@ template <typename T>
   struct dynamic_multiplicity
   {
 	  std::size_t low{};
-	  std::size_t high{low};
+	  std::size_t high{};
+
+    explicit dynamic_multiplicity(std::size_t _low, std::size_t _high = _low) noexcept
+	    : low{_low},
+		high{_high}
+    {
+    }
   };
 
   template <typename R, typename Parent>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,6 +210,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     add_compile_options(/permissive-)
   endif()
 
+  add_compile_definitions(NOMINMAX)
+
 endif() # MSVC
 
 if (${CMAKE_CXX_STANDARD} GREATER_EQUAL 20)

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -17,6 +17,7 @@
 
 #if defined(CATCH2_VERSION) && CATCH2_VERSION == 3
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #else
 #include <catch2/catch.hpp>
 #endif

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4838,8 +4838,8 @@ TEST_CASE_METHOD(
 
     SECTION("For arbitrary valid bounds.")
     {
-	    const std::size_t min = GENERATE(range<std::size_t>(0, 5));
-    	const std::size_t max = min + GENERATE(range<std::size_t>(0, 5));
+	    const std::size_t min = GENERATE(0u, 1u, 2u, 3u, 4u);
+    	const std::size_t max = min + GENERATE(0u, 1u, 2u, 3u, 4u);
     	auto e = NAMED_REQUIRE_CALL_V(obj, count(),
 		  .DYN_TIMES(min, max)
 		  .RETURN(1));
@@ -4870,8 +4870,8 @@ TEST_CASE_METHOD(
 
     SECTION("When invalid bounds are given.")
     {
-        const std::size_t max = GENERATE(range<std::size_t>(0, 5));
-	    const std::size_t min = max + GENERATE(range<std::size_t>(1, 5));
+        const std::size_t max = GENERATE(0u, 1u, 2u, 3u, 4u);
+	    const std::size_t min = max + GENERATE(1u, 2u, 3u, 4u);
 
         REQUIRE_THROWS_AS(
 	        (NAMED_REQUIRE_CALL_V(obj, count(),
@@ -4891,7 +4891,7 @@ TEST_CASE_METHOD(
   {
     mock_c obj;
 
-    const std::size_t count = GENERATE(range<std::size_t>(0, 5));
+    const std::size_t count = GENERATE(0u, 1u, 2u, 3u, 4u);
     auto e = NAMED_REQUIRE_CALL_V(obj, count(),
 	  .DYN_TIMES(AT_LEAST(count))
 	  .RETURN(1));
@@ -4920,7 +4920,7 @@ TEST_CASE_METHOD(
   {
     mock_c obj;
 
-    const std::size_t count = GENERATE(range<std::size_t>(0, 5));
+    const std::size_t count = GENERATE(0u, 1u, 2u, 3u, 4u);
     auto e = NAMED_REQUIRE_CALL_V(obj, count(),
 	  .DYN_TIMES(AT_MOST(count))
 	  .RETURN(1));

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4831,7 +4831,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
-  "C++11: .DYN_TIMES is satisfied when min calls is reached, and not saturated until max calls is reached",
+  "C++11: .RT_TIMES is satisfied when min calls is reached, and not saturated until max calls is reached",
   "[C++11][C++14][multiplicity]")
 {
   {
@@ -4842,7 +4842,7 @@ TEST_CASE_METHOD(
 	    const std::size_t min = GENERATE(0u, 1u, 2u, 3u, 4u);
     	const std::size_t max = min + GENERATE(0u, 1u, 2u, 3u, 4u);
     	auto e = NAMED_REQUIRE_CALL_V(obj, count(),
-		  .DYN_TIMES(min, max)
+		  .RT_TIMES(min, max)
 		  .RETURN(1));
 
     	for (std::size_t i{0};
@@ -4877,7 +4877,7 @@ TEST_CASE_METHOD(
         const auto makeExpectation = [&]()
         {
             REQUIRE_CALL_V(obj, count(),
-				.DYN_TIMES(min, max)
+				.RT_TIMES(min, max)
 				.RETURN(1));
         };
         REQUIRE_THROWS_AS(
@@ -4890,7 +4890,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
-  "C++11: .DYN_TIMES with AT_LEAST is satisfied when count calls is reached, but never saturated.",
+  "C++11: .RT_TIMES with AT_LEAST is satisfied when count calls is reached, but never saturated.",
   "[C++11][C++14][multiplicity]")
 {
   {
@@ -4898,7 +4898,7 @@ TEST_CASE_METHOD(
 
     const std::size_t count = GENERATE(0u, 1u, 2u, 3u, 4u);
     auto e = NAMED_REQUIRE_CALL_V(obj, count(),
-	  .DYN_TIMES(AT_LEAST(count))
+	  .RT_TIMES(AT_LEAST(count))
 	  .RETURN(1));
 
     for (std::size_t i{0};
@@ -4919,7 +4919,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
   Fixture,
-  "C++11: .DYN_TIMES with AT_MOST is satisfied until count calls is reached, and saturaded when exactly count calls are made.",
+  "C++11: .RT_TIMES with AT_MOST is satisfied until count calls is reached, and saturaded when exactly count calls are made.",
   "[C++11][C++14][multiplicity]")
 {
   {
@@ -4927,7 +4927,7 @@ TEST_CASE_METHOD(
 
     const std::size_t count = GENERATE(0u, 1u, 2u, 3u, 4u);
     auto e = NAMED_REQUIRE_CALL_V(obj, count(),
-	  .DYN_TIMES(AT_MOST(count))
+	  .RT_TIMES(AT_MOST(count))
 	  .RETURN(1));
 
     for (std::size_t i{0};

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -4874,10 +4874,14 @@ TEST_CASE_METHOD(
         const std::size_t max = GENERATE(0u, 1u, 2u, 3u, 4u);
 	    const std::size_t min = max + GENERATE(1u, 2u, 3u, 4u);
 
+        const auto makeExpectation = [&]()
+        {
+            REQUIRE_CALL_V(obj, count(),
+				.DYN_TIMES(min, max)
+				.RETURN(1));
+        };
         REQUIRE_THROWS_AS(
-	        (NAMED_REQUIRE_CALL_V(obj, count(),
-			  .DYN_TIMES(min, max)
-			  .RETURN(1))),
+            makeExpectation(),
 	        std::logic_error);
     }
   }

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -6096,14 +6096,14 @@ TEST_CASE_METHOD(
 )
 {
   bool called = false;
-	auto set_expectation = [&called](movable_mock obj) {
-	auto exp = NAMED_REQUIRE_CALL_V(obj, func(3),
-									.LR_SIDE_EFFECT(called = true));
-	return std::make_pair(std::move(obj), std::move(exp));
-	};
+  auto set_expectation = [&called](movable_mock obj) {
+    auto exp = NAMED_REQUIRE_CALL_V(obj, func(3),
+                                  .LR_SIDE_EFFECT(called = true));
+    return std::make_pair(std::move(obj), std::move(exp));
+  };
 
-	auto e = set_expectation(movable_mock{});
-	e.first.func(3);
+  auto e = set_expectation(movable_mock{});
+  e.first.func(3);
   REQUIRE(reports.empty());
   REQUIRE(called);
 }


### PR DESCRIPTION
as discussed in this issue https://github.com/rollbear/trompeloeil/issues/283 it would be very helpful to have the TIMES action configurable with runtime arguments.
This PR aims to add that, without making too much changes to existing symbols (in fact, no changes are made at all).

As this is mainly a sketchup for the actual feature, I'm open for feedback regarding behavior and naming (maybe ``RT_TIMES is a more appropriate name).