### PR TITLE
Fix memory leak during expectation construction

### DIFF
--- a/include/trompeloeil/coro.hpp
+++ b/include/trompeloeil/coro.hpp
@@ -204,7 +204,7 @@ namespace trompeloeil
         auto expr = new yield_expr<signature, E>(std::forward<E>(e));
         m.matcher->yield_expressions->push_back(expr);
       }
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 
@@ -261,7 +261,7 @@ namespace trompeloeil
           m.matcher->yield_expressions)
         );
       }
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 
@@ -303,7 +303,7 @@ namespace trompeloeil
         m.matcher->return_handler_obj.reset(new ret_handler(std::move(handler),
                                                             m.matcher->yield_expressions));
       }
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -2538,9 +2538,9 @@ template <typename T>
     using Parent::side_effects;
 
     call_modifier(
-       Matcher* m)
+       std::unique_ptr<Matcher>&& m)
     noexcept
-      : matcher{m}
+      : matcher{std::move(m)}
     {}
 
     template <typename F, typename ... Ts>
@@ -2569,9 +2569,9 @@ template <typename T>
                     "IN_SEQUENCE for forbidden call does not make sense");
 
       matcher->set_sequence(std::forward<T>(t)...);
-      return {matcher};
+      return {std::move(matcher)};
     }
-    Matcher* matcher;
+    std::unique_ptr<Matcher> matcher;
   };
 
   struct with
@@ -2671,7 +2671,7 @@ template <typename T>
       constexpr bool valid = !is_coroutine && !is_illegal_type && matching_ret_type && is_first_return && !Parent::throws && Parent::upper_call_limit > 0;
       using tag = std::integral_constant<bool, valid>;
       m.matcher->set_return(tag{}, std::forward<H>(h));
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 
@@ -2703,7 +2703,7 @@ template <typename T>
       using tag = std::integral_constant<bool, valid>;
       auto handler = throw_handler_t<H, signature>(std::forward<H>(h));
       m.matcher->set_return(tag{}, std::move(handler));
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 
@@ -2738,7 +2738,7 @@ template <typename T>
                     "IN_SEQUENCE and TIMES(0) does not make sense");
 
       m.matcher->sequences->set_limits(L, H);
-      return {m.matcher};
+      return {std::move(m).matcher};
     }
   };
 
@@ -3117,7 +3117,7 @@ template <typename T>
     auto
     make_expectation(
       std::true_type,
-      call_modifier<M, Tag, Info> const& m)
+      call_modifier<M, Tag, Info>&& m)
     const
     noexcept
     TROMPELOEIL_TRAILING_RETURN_TYPE(std::unique_ptr<expectation>)
@@ -3125,7 +3125,7 @@ template <typename T>
       auto lock = get_lock();
       m.matcher->hook_last(obj.trompeloeil_matcher_list(static_cast<Tag*>(nullptr)));
 
-      return std::unique_ptr<expectation>(m.matcher);
+      return std::move(m).matcher;
     }
 
     template <typename T>
@@ -3563,12 +3563,12 @@ template <typename T>
                           TROMPELOEIL_REMOVE_PAREN(sig),                       \
                           ::trompeloeil::param_t<trompeloeil_param_type...>>;  \
       return {                                                                 \
-          new matcher {                                                        \
+          std::make_unique<matcher>(                                           \
                 trompeloeil_expectation_file,                                  \
                 trompeloeil_expectation_line,                                  \
                 trompeloeil_expectation_string,                                \
                 std::forward<trompeloeil_param_type>(trompeloeil_param)...     \
-              }                                                                \
+              )                                                                \
       };                                                                       \
     }                                                                          \
   };                                                                           \

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -3563,7 +3563,7 @@ template <typename T>
                           TROMPELOEIL_REMOVE_PAREN(sig),                       \
                           ::trompeloeil::param_t<trompeloeil_param_type...>>;  \
       return {                                                                 \
-          std::make_unique<matcher>(                                           \
+          ::trompeloeil::detail::make_unique<matcher>(                         \
                 trompeloeil_expectation_file,                                  \
                 trompeloeil_expectation_line,                                  \
                 trompeloeil_expectation_string,                                \

--- a/test/compiling_tests_11.cpp
+++ b/test/compiling_tests_11.cpp
@@ -152,10 +152,12 @@ TEST_CASE(
   // this test shall not check any testable errors, but instead is intended to force memory leaks during
   // expectation construction
   mock_c mock{};
+  trompeloeil::sequence seq{};
 
   const auto makeExpectation = [&]
   {
     REQUIRE_CALL_V(mock, getter(42),
+      .IN_SEQUENCE(seq)
 	  .TIMES(2)
 	  .SIDE_EFFECT()
 	  .WITH(true)


### PR DESCRIPTION
As discussed here https://github.com/rollbear/trompeloeil/pull/333 there exists a memory leak when creating expectations and a exception raises.

As its very hard to create a test for that, I use this PR and your the ci output as proof, that the issue is fixed. Hopefully its not too annoying. :)

See action run https://github.com/rollbear/trompeloeil/actions/runs/8680521953?pr=334 as a baseline, where I created a test to provoke the issue.