### PR TITLE
Update docs for Catch2 3.x integration

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -251,13 +251,14 @@ All tests passed (2 assertions in 1 test case)
 
 The easiest way to use *Trompeloeil* with *Catch2* is to
 `#include <catch2/trompeloeil.hpp>` in your test .cpp files. Note that the
-inclusion order is important. `<catch.hpp>` must be included before
-`<catch/trompeloeil.hpp>`.
+inclusion order is important. `<catch.hpp>` (Catch2 2.x) or
+`<catch2/catch_test_macros.hpp>` (Catch2 3.x) must be included before
+`<catch2/trompeloeil.hpp>`.
 
 Like this:
 
 ```Cpp
-#include <catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <catch2/trompeloeil.hpp>
 
 TEST_CASE("...


### PR DESCRIPTION
According to #272 and its fix #278, (only) `catch2/catch_test_macros.hpp` needs to be included from Catch2 3.x.
This updates the documentation accordingly.

- Clarify required header from Catch2 3.x
- Fix typo in header name (was: "catch/trompeloeil.hpp")