### PR TITLE
Fix feature detection of __VA_OPT__ for MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1676,6 +1676,13 @@ jobs:
             cxx_standard: 20,
           }
           - {
+            name: "Windows MSVC 2022 C++20 __cppstd",
+            os: windows-2022,
+            cc: "cl", cxx: "cl",
+            cxx_standard: 20,
+            cxx_flags: "/Zc:__cplusplus"
+          }
+          - {
             name: "Windows MSVC 2022 C++20 preprocessor",
             os: windows-2022,
             cc: "cl", cxx: "cl",
@@ -1728,6 +1735,13 @@ jobs:
             os: windows-2019,
             cc: "cl", cxx: "cl",
             cxx_standard: 20,
+          }
+          - {
+            name: "Windows MSVC 2019 C++20 __cppstd",
+            os: windows-2019,
+            cc: "cl", cxx: "cl",
+            cxx_standard: 20,
+            cxx_flags: "/Zc:__cplusplus"
           }
           - {
             name: "Windows MSVC 2019 C++20 preprocessor",

--- a/include/trompeloeil/mock.hpp
+++ b/include/trompeloeil/mock.hpp
@@ -122,13 +122,15 @@
 #define TROMPELOEIL_NOT_IMPLEMENTED(...) __VA_ARGS__
 #endif
 
-#if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL==0
-#  if _MSC_VER >= 1940
-#    define TROMPELOEIL_HAS_VA_OPT 1
-#  else
-#    define TROMPELOEIL_HAS_VA_OPT 0
+#if defined(_MSVC_TRADITIONAL)
+#  if _MSVC_TRADITIONAL==0
+#    if (_MSC_VER >= 1940) || ((_MSVC_VER >= 1926) &&  (_MSVC_LANG > 201703L))
+#      define TROMPELOEIL_HAS_VA_OPT 1
+#    else
+#      define TROMPELOEIL_HAS_VA_OPT 0
+#    endif
+#    define TROMPELOEIL_MSVC_PREPROCESSOR 0
 #  endif
-#  define TROMPELOEIL_MSVC_PREPROCESSOR 0
 #elif __cplusplus >= 202002L
 #  define TROMPELOEIL_HAS_VA_OPT 1
 #else


### PR DESCRIPTION
- Add VS2019 and VS2022 runs where `__cplusplus >= 202002L` is combined with `/Zc:preprocessor-` (and fail to preprocess correctly).

See https://github.com/puetzk/trompeloeil/actions/runs/14110751749 for an example where the new CI configurations (without the corresponding fix) fail to compile, because they try to use `__VA_OPT__` in a configuration where the preprocessor does not support it.

With the second commit (fixing the detection macro), all of the configurations now run, three of them with different behavior:
- "Windows MSVC 2019 C++20 preprocessor" should detect that it *does* have `__VA_OPT__`  (because it's >= 16.6, /`Zc:preprocessor` is on, and `/std:c++20` was set, making `_MSVC_TRADITIONAL=0` and `_MSVC_LANG=202002L`.

- "Windows MSVC 2019 C++20 __cppstd" and "Windows MSVC 2022 C++20 __cppstd" now see that they do *not* have `__VA_OPT__` (because it's using the old preprocessor, despite being `__cplusplus >= 202002L`

Fixes #343