### PR TITLE
Use FAIL_CHECK macro to report non-fatal failures to Catch2

### DIFF
--- a/docs/CookBook.md
+++ b/docs/CookBook.md
@@ -286,8 +286,7 @@ Before running any tests, make sure to call:
     }
     else
     {
-      CAPTURE(failure);
-      CHECK(failure.empty());
+      FAIL_CHECK(failure);
     }
   });
 ```

--- a/include/catch2/trompeloeil.hpp
+++ b/include/catch2/trompeloeil.hpp
@@ -47,11 +47,9 @@ namespace trompeloeil
     else
     {
 #ifdef CATCH_CONFIG_PREFIX_ALL
-      CATCH_CAPTURE(failure);
-      CATCH_CHECK(failure.empty());
+      CATCH_FAIL_CHECK(failure);
 #else
-      CAPTURE(failure);
-      CHECK(failure.empty());
+      FAIL_CHECK(failure);
 #endif
     }
   }

--- a/include/catch2/trompeloeil.hpp
+++ b/include/catch2/trompeloeil.hpp
@@ -59,9 +59,9 @@ namespace trompeloeil
     const char* trompeloeil_mock_calls_done_correctly)
   {      
 #ifdef CATCH_CONFIG_PREFIX_ALL
-      CATCH_REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
+      CATCH_SUCCEED(trompeloeil_mock_calls_done_correctly);
 #else
-      REQUIRE(trompeloeil_mock_calls_done_correctly != 0);
+      SUCCEED(trompeloeil_mock_calls_done_correctly);
 #endif
   }
 }


### PR DESCRIPTION
This avoids a two-step dance of first capturing a local variable and then doing a roundabout CHECK(false);

The previous approach produces a somewhat cluttered error message, that primarily describes the expression `failure.empty() == false`, showing the real issue only as an extra "failure := "..." variable (which is presented as a quoted value, and possible truncated).

```
.../catch2/trompeloeil.hpp(52): FAILED:
  CHECK( failure.empty() )
with expansion:
  false
with message:
  failure := "test.cpp:15
  Unfulfilled expectation:
  Expected mock.foo(42) to be called once, actually never called
    param  _1 == 42
  "
```

Using `FAIL_CHECK` puts the real message up front, with no extra quoting. Like `CHECK(false)` (but unlike `FAIL`) it allows execution to continue.

```
.../catch2/trompeloeil.hpp(52): FAILED:
explicitly with message:
  test.cpp:15
  Unfulfilled expectation:
  Expected mock.foo(42) to be called once, actually never called
    param  _1 == 42
```

`FAIL_CHECK` has been available since Catch [1.8.2](https://github.com/catchorg/Catch2/releases/tag/v1.8.2), i.e. before it was Catch2, so I don't think there's a compatibility concern.