### PR TITLE
Add support for free coroutine operators

### DIFF
--- a/include/trompeloeil/coro.hpp
+++ b/include/trompeloeil/coro.hpp
@@ -51,6 +51,11 @@ namespace trompeloeil
         return type_wrapper<decltype(std::declval<T>().operator co_await().await_resume())>{};
       }
       else
+      if constexpr (requires(T coro) { operator co_await(std::declval<T>()); })
+      {
+        return type_wrapper<decltype(operator co_await(std::declval<T>()).await_resume())>{};
+      }
+      else
       if constexpr (requires(T coro){ coro.await_resume(); })
       {
         return type_wrapper<decltype(std::declval<T>().await_resume())>{};

--- a/test/micro_coro.hpp
+++ b/test/micro_coro.hpp
@@ -342,6 +342,91 @@ namespace coro
   }
 
   template <typename>
+  struct co_await_task;
+
+  template <typename T>
+  struct co_await_promise : promise<T>
+  {
+    co_await_task<T>
+    get_return_object() noexcept;
+  };
+
+  template <typename T>
+  struct co_await_task
+  {
+    using promise_type = co_await_promise<T>;
+
+    explicit co_await_task(std::coroutine_handle<promise_type> h = nullptr) : coroutine_(h) {}
+
+    co_await_task(co_await_task &&h) : coroutine_(std::exchange(h.coroutine_, nullptr)) {}
+
+    ~co_await_task()
+    {
+      if (coroutine_) {
+        coroutine_.destroy();
+      }
+    }
+
+    std::coroutine_handle<promise_type>
+    handle()
+      const
+      noexcept
+    {
+      return coroutine_;
+    }
+
+    promise_type &
+    promise()
+      const
+    {
+      return coroutine_.promise();
+    }
+
+  private:
+    std::coroutine_handle<promise_type> coroutine_;
+  };
+
+  template <typename T>
+  auto
+  operator co_await(const co_await_task<T> &t) noexcept
+  {
+    struct awaitable
+    {
+      bool
+      await_ready()
+        const
+        noexcept
+      {
+        return coroutine_.promise().has_data();
+      }
+
+      std::coroutine_handle<>
+      await_suspend(std::coroutine_handle<> next) noexcept
+      {
+        coroutine_.promise().continuation(next);
+        return coroutine_;
+      }
+
+      decltype(auto)
+      await_resume()
+      {
+        return coroutine_.promise().result();
+      }
+
+      std::coroutine_handle<co_await_promise<T>> coroutine_;
+    };
+    return awaitable{t.handle()};
+  }
+
+  template <typename T>
+  co_await_task<T>
+  co_await_promise<T>::get_return_object() noexcept
+  {
+    return co_await_task<T>{
+      std::coroutine_handle<co_await_promise>::from_promise(*this)};
+  }
+
+  template <typename>
   struct generator;
 
   template<typename T>

--- a/test/test_co_mock.cpp
+++ b/test/test_co_mock.cpp
@@ -41,6 +41,10 @@ namespace {
     MAKE_MOCK1 (unique, coro::task<iptr>(iptr));
     MAKE_MOCK0 (gen, coro::generator<int>());
 
+    MAKE_MOCK0(free_intret, coro::co_await_task<int>());
+    MAKE_MOCK0(free_voidret, coro::co_await_task<void>());
+    MAKE_MOCK1(free_unique, coro::co_await_task<iptr>(iptr));
+
 #ifdef __cpp_lib_generator
     MAKE_MOCK0 (stdgen, std::generator<int>());
 #endif // __cpp_lib_generator
@@ -206,6 +210,92 @@ TEST_CASE_METHOD(
     std::invoke([&]() -> coro::task<void> { v = co_await p;});
     REQUIRE(v == 3);
     REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+    Fixture,
+    "A CO_RETURNed value is obtained from co_await with a free operator co_await",
+    "[coro]")
+{
+  co_mock m;
+  REQUIRE_CALL(m, free_intret()).CO_RETURN(3);
+
+  int x = 0;
+  std::invoke([&]() -> coro::task<void>
+              { x = co_await m.free_intret(); });
+
+  REQUIRE(x == 3);
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+    Fixture,
+    "A void co_routine is CO_RETURNed with a free operator co_await",
+    "[coro]")
+{
+  co_mock m;
+  REQUIRE_CALL(m, free_voidret()).CO_RETURN();
+
+  int x = 0;
+  std::invoke([&]() -> coro::task<void>
+              { co_await m.free_voidret(); x = 3; });
+
+  REQUIRE(x == 3);
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+    Fixture,
+    "A move-only type can be CO_RETURNed with a free operator co_await",
+    "[coro]")
+{
+  co_mock m;
+  REQUIRE_CALL(m, free_unique(_)).CO_RETURN(std::move(_1));
+  auto p = m.free_unique(std::make_unique<int>(3));
+  iptr x;
+  std::invoke([&]() -> coro::task<void>
+              { x = co_await p; });
+  REQUIRE(x);
+  REQUIRE(*x == 3);
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+    Fixture,
+    "Exception from CO_THROW is thrown from co_await with a free operator co_await",
+    "[coro]")
+{
+  co_mock m;
+  REQUIRE_CALL(m, free_intret()).CO_THROW("foo");
+  auto p = m.free_intret();
+  int x = 0;
+  std::invoke([&]() -> coro::task<void>
+              {
+    REQUIRE_THROWS(co_await p);
+    x = 1; });
+  REQUIRE(x == 1);
+  REQUIRE(reports.empty());
+}
+
+TEST_CASE_METHOD(
+    Fixture,
+    "CO_YIELDed values are co_await:ed in order with CO_RETURN last with a free operator co_await",
+    "[coro]")
+{
+  co_mock m;
+  REQUIRE_CALL(m, free_intret()).CO_YIELD(1).CO_YIELD(2).CO_RETURN(0);
+  auto p = m.free_intret();
+  int v = 0;
+  std::invoke([&]() -> coro::task<void>
+              { v = co_await p; });
+  REQUIRE(v == 1);
+  std::invoke([&]() -> coro::task<void>
+              { v = co_await p; });
+  REQUIRE(v == 2);
+  std::invoke([&]() -> coro::task<void>
+              { v = co_await p; });
+  REQUIRE(v == 0);
+  REQUIRE(reports.empty());
 }
 
 #ifdef __cpp_lib_generator


### PR DESCRIPTION
Fixes #364. I didn't end up adding any compilation_errors tests as this seems to be an instance where we are turning an existing failure case into something that now compiles - but let me know if you disagree.

(Tests written by AI, vetted by me before PR creation - though they're pretty much just carbon copies of the existing ones.)